### PR TITLE
feat: add --release-time for scheduled release (定时发布)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,23 @@ apkgo version                                     # Version info (JSON)
 -s, --store        Comma-separated store names (default: all configured)
 -n, --notes        Release notes text
     --notes-file   Read release notes from file (overrides --notes)
+    --release-time Schedule a timed release (定时发布) at an RFC3339 time, e.g. 2026-06-20T10:00:00+08:00
     --dry-run      Validate without uploading
 -t, --timeout      Global timeout (default: 10m)
 -c, --config       Config file path (default: apkgo.yaml)
 -o, --output       Output format: json or text (default: json)
 ```
+
+### Scheduled release (`--release-time`)
+
+Schedules a timed release instead of going live immediately after review.
+Value is RFC3339 **with a timezone offset** and must be in the future.
+Supported stores: **huawei, honor, xiaomi, oppo, vivo, samsung, tencent**
+(see `supports_scheduled_release` in `apkgo stores`). Stores that can't
+schedule (googleplay, pgyer, fir, script) log a warning and release
+immediately. Each store maps the instant to its own field/format
+internally — epoch-based stores use the absolute instant; oppo/vivo/samsung
+render it in Beijing time (UTC+8).
 
 ## Supported stores
 

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/vbauerster/mpb/v8"
@@ -24,6 +25,7 @@ var (
 	flagStore          string
 	flagNotes          string
 	flagNotesFile      string
+	flagReleaseTime    string
 	flagDryRun         bool
 	flagFetchHeaders   []string
 	flagProgressStream bool
@@ -35,6 +37,7 @@ func init() {
 	uploadCmd.Flags().StringVarP(&flagStore, "store", "s", "", "comma-separated store names (default: all configured)")
 	uploadCmd.Flags().StringVarP(&flagNotes, "notes", "n", "", "release notes (text)")
 	uploadCmd.Flags().StringVar(&flagNotesFile, "notes-file", "", "read release notes from file (overrides --notes)")
+	uploadCmd.Flags().StringVar(&flagReleaseTime, "release-time", "", "schedule a timed release (定时发布) at an RFC3339 time, e.g. 2026-06-20T10:00:00+08:00 (supported: huawei,honor,xiaomi,oppo,vivo,samsung,tencent; others release immediately)")
 	uploadCmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "validate config and APK without uploading")
 	uploadCmd.Flags().StringArrayVar(&flagFetchHeaders, "fetch-header", nil, `extra HTTP header for URL fetches (repeatable; "Name: value")`)
 	uploadCmd.Flags().BoolVar(&flagProgressStream, "progress-stream", false, "emit NDJSON progress events on stdout (one JSON object per line) for parent-process consumption")
@@ -75,6 +78,14 @@ var uploadCmd = &cobra.Command{
 			return err
 		}
 
+		var releaseTime time.Time
+		if flagReleaseTime != "" {
+			releaseTime, err = time.Parse(time.RFC3339, flagReleaseTime)
+			if err != nil {
+				return fmt.Errorf("invalid --release-time %q (want RFC3339 with timezone, e.g. 2026-06-20T10:00:00+08:00): %w", flagReleaseTime, err)
+			}
+		}
+
 		cfg, err := loadConfigForCmd()
 		if err != nil {
 			return fmt.Errorf("config: %w", err)
@@ -96,6 +107,7 @@ var uploadCmd = &cobra.Command{
 			Stores:       stores,
 			Notes:        flagNotes,
 			NotesFile:    flagNotesFile,
+			ReleaseTime:  releaseTime,
 			Config:       cfg,
 			FetchHeaders: fetchHeaders,
 			Progress:     pm,

--- a/pkg/apkgo/job.go
+++ b/pkg/apkgo/job.go
@@ -63,6 +63,14 @@ type Job struct {
 	// (trimmed) are used instead.
 	NotesFile string
 
+	// ReleaseTime, when non-zero, schedules a timed release (定时发布) at
+	// that instant on stores that support it (huawei, honor, xiaomi,
+	// oppo, vivo, samsung, tencent). Stores that can't schedule
+	// (googleplay, pgyer, fir, script) log a warning and release
+	// immediately. The value carries its own timezone offset. Zero means
+	// immediate release (the default, unchanged behaviour).
+	ReleaseTime time.Time
+
 	// Config is the resolved store + hooks config. Required.
 	Config *config.Config
 
@@ -197,6 +205,30 @@ func Run(ctx context.Context, job Job) (*Result, error) {
 		}
 	}
 
+	// Scheduled release (定时发布): ReleaseTime carries its own timezone;
+	// each store converts to its own field+format. Per design we warn —
+	// not fail — when targeted stores can't schedule, and they publish
+	// immediately. Runs before the dry-run return so --dry-run is a real
+	// preflight for the schedule too.
+	var releaseTime *time.Time
+	if !job.ReleaseTime.IsZero() {
+		if !job.ReleaseTime.After(time.Now()) {
+			return nil, fmt.Errorf("release-time must be in the future, got %s", job.ReleaseTime.Format(time.RFC3339))
+		}
+		rt := job.ReleaseTime
+		releaseTime = &rt
+		var unsupported []string
+		for _, name := range storeNames {
+			if !store.SupportsScheduledRelease(name) {
+				unsupported = append(unsupported, name)
+			}
+		}
+		if len(unsupported) > 0 {
+			ctxlog.FromContext(ctx).Warn("scheduled release not supported by some stores; they will publish immediately",
+				"release_time", job.ReleaseTime.Format(time.RFC3339), "stores", unsupported)
+		}
+	}
+
 	// Reject AAB up-front for stores that don't accept it — Chinese
 	// stores all want APKs, and silently letting the upload reach them
 	// produces inscrutable server-side errors mid-run.
@@ -241,6 +273,7 @@ func Run(ctx context.Context, job Job) (*Result, error) {
 		VersionCode:  info.VersionCode,
 		VersionName:  info.VersionName,
 		ReleaseNotes: notes,
+		ReleaseTime:  releaseTime,
 	}
 
 	hookEnv := map[string]string{

--- a/pkg/store/honor/honor.go
+++ b/pkg/store/honor/honor.go
@@ -24,8 +24,9 @@ import (
 
 func init() {
 	store.Register("honor", store.ConfigSchema{
-		Name:       "honor",
-		ConsoleURL: "https://developer.honor.com/cn/doc/guides/101360",
+		Name:                     "honor",
+		ConsoleURL:               "https://developer.honor.com/cn/doc/guides/101360",
+		SupportsScheduledRelease: true,
 		Fields: []store.FieldSchema{
 			{Key: "client_id", Required: true, Desc: "Honor developer API client ID"},
 			{Key: "client_secret", Required: true, Desc: "Honor developer API client secret"},
@@ -139,7 +140,7 @@ func (s *Store) upload(ctx context.Context, req *store.UploadRequest) error {
 	}
 
 	rep.Phase("submitting")
-	return s.submitAudit(appID)
+	return s.submitAudit(appID, req.ReleaseTime)
 }
 
 // ---- auth ----
@@ -422,13 +423,20 @@ func (s *Store) updateLanguageInfo(appID string, existing *languageInfo, release
 
 // ---- submit ----
 
-func (s *Store) submitAudit(appID string) error {
+func (s *Store) submitAudit(appID string, releaseTime *time.Time) error {
 	var resp honorResp
+	body := map[string]any{
+		"releaseType": 1, // 1 = 全网发布
+	}
+	if releaseTime != nil {
+		// Scheduled release (定时发布): releaseType 2 = 指定时间发布, with
+		// releaseTime in UTC format with offset (e.g. 2026-06-20T10:00:00+0800).
+		body["releaseType"] = 2
+		body["releaseTime"] = releaseTime.Format("2006-01-02T15:04:05Z0700")
+	}
 	httpResp, err := s.client.R().
 		SetQueryParam("appId", appID).
-		SetBody(map[string]any{
-			"releaseType": 1, // 1 = 全网发布
-		}).
+		SetBody(body).
 		SetResult(&resp).
 		Post("/openapi/v1/publish/submit-audit")
 	if err != nil {
@@ -484,9 +492,9 @@ func statAndSha256(path string) (size int64, hashHex string, err error) {
 //
 //  1. token       — credentials exchange for an OAuth2 access token
 //  2. get-app-id  — package resolves to an appId under this developer
-//                   account (skipped if app_id was supplied in config)
+//     account (skipped if app_id was supplied in config)
 //  3. app-detail  — the access token has read access to the app, used
-//                   to confirm the publish-API permission scope
+//     to confirm the publish-API permission scope
 func diagnose(ctx context.Context, cfg map[string]string, hint store.DiagnoseHint) []store.Probe {
 	probes := make([]store.Probe, 0, 3)
 

--- a/pkg/store/huawei/huawei.go
+++ b/pkg/store/huawei/huawei.go
@@ -20,8 +20,9 @@ import (
 
 func init() {
 	store.Register("huawei", store.ConfigSchema{
-		Name:       "huawei",
-		ConsoleURL: "https://developer.huawei.com/consumer/cn/doc/AppGallery-connect-Guides/agcapi-getstarted-0000001111845114#section1785535363715",
+		Name:                     "huawei",
+		ConsoleURL:               "https://developer.huawei.com/consumer/cn/doc/AppGallery-connect-Guides/agcapi-getstarted-0000001111845114#section1785535363715",
+		SupportsScheduledRelease: true,
 		Fields: []store.FieldSchema{
 			{Key: "service_account", Required: false, Desc: "Service Account credential JSON (raw or base64); recommended"},
 			{Key: "service_account_file", Required: false, Desc: "Path to Service Account credential JSON file"},
@@ -138,7 +139,7 @@ func (s *Store) upload(ctx context.Context, req *store.UploadRequest) error {
 
 	// Poll for compilation readiness then submit
 	rep.Phase("submitting")
-	if err := s.pollAndSubmit(ctx, appID); err != nil {
+	if err := s.pollAndSubmit(ctx, appID, req.ReleaseTime); err != nil {
 		return err
 	}
 	return nil
@@ -346,13 +347,13 @@ const hwConsoleURL = "https://developer.huawei.com/consumer/cn/console"
 // also come back as 204144660, so we must inspect the message and only
 // retry the "still parsing" subset; otherwise we'd burn 5 minutes hiding
 // an error the operator can fix immediately.
-func (s *Store) pollAndSubmit(ctx context.Context, appID string) error {
+func (s *Store) pollAndSubmit(ctx context.Context, appID string, releaseTime *time.Time) error {
 	wrap := func(format string, args ...any) error {
 		return fmt.Errorf(format+" (APK 已上传成功，请在 AGC 后台完成审核：%s)", append(args, hwConsoleURL)...)
 	}
 
 	// Immediate attempt so fast-parsing APKs don't wait 30s for nothing.
-	ret, err := s.submitApp(appID)
+	ret, err := s.submitApp(appID, releaseTime)
 	if err != nil {
 		return wrap("submit: %v", err)
 	}
@@ -377,7 +378,7 @@ func (s *Store) pollAndSubmit(ctx context.Context, appID string) error {
 		case <-ticker.C:
 		}
 
-		ret, err := s.submitApp(appID)
+		ret, err := s.submitApp(appID, releaseTime)
 		if err != nil {
 			return wrap("submit: %v", err)
 		}
@@ -417,15 +418,22 @@ func isParsingInProgress(ret retInfo) bool {
 // HTTP-level failures (transport error, non-2xx with no parseable ret)
 // are surfaced as the second return value rather than being silently
 // converted into a zero-valued ret, which would look like success.
-func (s *Store) submitApp(appID string) (retInfo, error) {
+func (s *Store) submitApp(appID string, releaseTime *time.Time) (retInfo, error) {
 	var resp struct {
 		Ret retInfo `json:"ret"`
 	}
+	query := map[string]string{
+		"appId":       appID,
+		"releaseType": "1",
+	}
+	if releaseTime != nil {
+		// Scheduled release (定时发布): Huawei's releaseTime query param,
+		// UTC format with offset (e.g. 2026-06-20T10:00:00+0800). When
+		// omitted the app goes live immediately after the review passes.
+		query["releaseTime"] = releaseTime.Format("2006-01-02T15:04:05Z0700")
+	}
 	httpResp, err := s.client.R().
-		SetQueryParams(map[string]string{
-			"appId":       appID,
-			"releaseType": "1",
-		}).
+		SetQueryParams(query).
 		SetBody(map[string]any{}).
 		SetResult(&resp).
 		Post("/api/publish/v2/app-submit")
@@ -471,7 +479,7 @@ func (s *Store) getUploadURL(appID string) (uploadURL, authCode string, err erro
 //  1. token              — credentials are accepted (catches wrong client_id type)
 //  2. appid-list         — package name resolves to an appId in this AGC team
 //  3. release-permission — upload-url returns a destination, which the API
-//                          only does when the API key has "App release" rights
+//     only does when the API key has "App release" rights
 //
 // Probes 2 and 3 require a package name (DiagnoseHint.Package). They are
 // reported as skipped when that hint is absent.

--- a/pkg/store/oppo/oppo.go
+++ b/pkg/store/oppo/oppo.go
@@ -26,8 +26,9 @@ import (
 
 func init() {
 	store.Register("oppo", store.ConfigSchema{
-		Name:       "oppo",
-		ConsoleURL: "https://open.oppomobile.com/new/developmentDoc/info?id=10998",
+		Name:                     "oppo",
+		ConsoleURL:               "https://open.oppomobile.com/new/developmentDoc/info?id=10998",
+		SupportsScheduledRelease: true,
 		Fields: []store.FieldSchema{
 			{Key: "client_id", Required: true, Desc: "OPPO open platform client ID"},
 			{Key: "client_secret", Required: true, Desc: "OPPO open platform client secret"},
@@ -343,6 +344,12 @@ func (s *Store) publish(req *store.UploadRequest, app *appData, apkInfos []apkIn
 	values.Set("icon_url", app.IconURL)
 	values.Set("pic_url", app.PicURL)
 	values.Set("online_type", "1")
+	if req.ReleaseTime != nil {
+		// Scheduled release (定时发布): online_type 2 = 定时发布, with
+		// sche_online_time as a Beijing-local datetime string.
+		values.Set("online_type", "2")
+		values.Set("sche_online_time", store.BeijingLocalTime(*req.ReleaseTime))
+	}
 	values.Set("test_desc", "submitted by apkgo")
 	values.Set("copyright_url", app.CopyrightURL)
 	values.Set("business_username", app.BusinessUsername)
@@ -485,9 +492,9 @@ type appData struct {
 }
 
 type uploadResultData struct {
-	URL  string `json:"url"`
-	MD5  string `json:"md5"`
-	ID   string `json:"id"`
+	URL string `json:"url"`
+	MD5 string `json:"md5"`
+	ID  string `json:"id"`
 }
 
 type apkInfo struct {
@@ -500,9 +507,9 @@ type apkInfo struct {
 //
 //  1. token       — credentials are accepted by /developer/v1/token
 //  2. app-info    — the package exists under this developer account, and
-//                   the HMAC-SHA256 signature is being computed correctly
-//                   (without a sig that lines up server-side, app/info
-//                   returns errno=… instead of the package data)
+//     the HMAC-SHA256 signature is being computed correctly
+//     (without a sig that lines up server-side, app/info
+//     returns errno=… instead of the package data)
 func diagnose(ctx context.Context, cfg map[string]string, hint store.DiagnoseHint) []store.Probe {
 	probes := make([]store.Probe, 0, 2)
 

--- a/pkg/store/registry.go
+++ b/pkg/store/registry.go
@@ -76,3 +76,16 @@ func AcceptsAAB(name string) bool {
 	}
 	return ok && e.schema.AcceptsAAB
 }
+
+// SupportsScheduledRelease reports whether the named store declared
+// scheduled-release (定时发布) support in its ConfigSchema. Uses the same
+// "type.instance" resolution as AcceptsAAB. Unknown names return false.
+func SupportsScheduledRelease(name string) bool {
+	e, ok := registry[name]
+	if !ok {
+		if dot := strings.Index(name, "."); dot > 0 {
+			e, ok = registry[name[:dot]]
+		}
+	}
+	return ok && e.schema.SupportsScheduledRelease
+}

--- a/pkg/store/samsung/samsung.go
+++ b/pkg/store/samsung/samsung.go
@@ -27,8 +27,9 @@ import (
 
 func init() {
 	store.Register("samsung", store.ConfigSchema{
-		Name:       "samsung",
-		ConsoleURL: "https://seller.samsungapps.com",
+		Name:                     "samsung",
+		ConsoleURL:               "https://seller.samsungapps.com",
+		SupportsScheduledRelease: true,
 		Fields: []store.FieldSchema{
 			{Key: "service_account_id", Required: true, Desc: "Samsung Seller Portal service account ID"},
 			{Key: "private_key", Required: true, Desc: "RSA private key (PEM) from Seller Portal"},
@@ -155,15 +156,23 @@ func (s *Store) upload(_ context.Context, req *store.UploadRequest) error {
 
 	// 3. Update content
 	rep.Phase("publishing")
+	contentBody := map[string]any{
+		"contentId": s.contentID,
+		"binaryList": []map[string]string{{
+			"fileKey":         uploadResp.FileKey,
+			"gmsYn":           "Y",
+			"nativePlatforms": "APK",
+		}},
+	}
+	if req.ReleaseTime != nil {
+		// Scheduled release: publicationType 02 = scheduled date, with
+		// startPublicationDate as a Beijing-local datetime string
+		// (01 = auto after review, 03 = manual).
+		contentBody["publicationType"] = "02"
+		contentBody["startPublicationDate"] = store.BeijingLocalTime(*req.ReleaseTime)
+	}
 	_, err = s.client.R().
-		SetBody(map[string]any{
-			"contentId": s.contentID,
-			"binaryList": []map[string]string{{
-				"fileKey":         uploadResp.FileKey,
-				"gmsYn":           "Y",
-				"nativePlatforms": "APK",
-			}},
-		}).
+		SetBody(contentBody).
 		Post("/seller/contentUpdate")
 	if err != nil {
 		return fmt.Errorf("update content: %w", err)

--- a/pkg/store/scheduled_test.go
+++ b/pkg/store/scheduled_test.go
@@ -1,0 +1,66 @@
+package store_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KevinGong2013/apkgo/v3/pkg/store"
+)
+
+// TestBeijingLocalTime locks in the timezone conversion used by the
+// scheduled-release fields of oppo, vivo and samsung, whose datetime
+// strings carry no timezone of their own and must be rendered in
+// Beijing time (UTC+8) regardless of the offset the caller supplied.
+func TestBeijingLocalTime(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string // RFC3339 input
+		want string
+	}{
+		{"already Beijing offset", "2026-06-20T10:00:00+08:00", "2026-06-20 10:00:00"},
+		{"from UTC", "2026-06-20T02:00:00Z", "2026-06-20 10:00:00"},
+		{"from US Eastern", "2026-06-20T00:00:00-05:00", "2026-06-20 13:00:00"},
+		{"crosses date boundary", "2026-06-20T23:30:00Z", "2026-06-21 07:30:00"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			parsed, err := time.Parse(time.RFC3339, c.in)
+			if err != nil {
+				t.Fatalf("parse %q: %v", c.in, err)
+			}
+			if got := store.BeijingLocalTime(parsed); got != c.want {
+				t.Errorf("BeijingLocalTime(%s) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// TestSupportsScheduledRelease verifies the capability lookup, including
+// the "type.instance" name resolution (e.g. "script.cdn") and the
+// unknown-name-is-false fallback that apkgo.Run relies on when deciding
+// which targeted stores to warn about.
+func TestSupportsScheduledRelease(t *testing.T) {
+	store.Register("test-sched-yes", store.ConfigSchema{
+		Name:                     "test-sched-yes",
+		SupportsScheduledRelease: true,
+	}, func(map[string]string) (store.Store, error) { return nil, nil })
+	store.Register("test-sched-no", store.ConfigSchema{
+		Name: "test-sched-no",
+	}, func(map[string]string) (store.Store, error) { return nil, nil })
+
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"test-sched-yes", true},
+		{"test-sched-no", false},
+		{"test-sched-yes.instance", true}, // type.instance resolves to base type
+		{"test-sched-no.instance", false},
+		{"unregistered", false},
+	}
+	for _, c := range cases {
+		if got := store.SupportsScheduledRelease(c.name); got != c.want {
+			t.Errorf("SupportsScheduledRelease(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -23,6 +23,16 @@ type UploadRequest struct {
 	VersionName  string
 	ReleaseNotes string
 
+	// ReleaseTime, when non-nil, requests a scheduled (定时/timed) release
+	// at that instant instead of the default "go live immediately after
+	// review". It carries a timezone offset: epoch-based stores (xiaomi,
+	// tencent) use it as an absolute instant; local-datetime stores (oppo,
+	// vivo, samsung) render it in Beijing time via BeijingLocalTime;
+	// huawei/honor send it with its offset. Stores that can't schedule
+	// (googleplay, pgyer, fir, script) ignore it and release immediately.
+	// nil = immediate (the default, unchanged behaviour).
+	ReleaseTime *time.Time `json:",omitempty"`
+
 	// Progress receives phase and byte-count events during upload.
 	// May be nil; stores must use progress.Safe() to guard against that.
 	// Tagged json:"-" so it's excluded when script-store marshals the
@@ -85,6 +95,11 @@ type ConfigSchema struct {
 	Fields     []FieldSchema `json:"fields"`
 	ConsoleURL string        `json:"console_url"`           // developer console URL where credentials are managed
 	AcceptsAAB bool          `json:"accepts_aab,omitempty"` // true if the store accepts .aab in addition to .apk
+	// SupportsScheduledRelease is true if the store's API can schedule a
+	// release for a future time (定时发布). Surfaced by `apkgo stores`;
+	// also drives the warning when --release-time targets a store that
+	// can't honor it.
+	SupportsScheduledRelease bool `json:"supports_scheduled_release,omitempty"`
 }
 
 type FieldSchema struct {
@@ -95,3 +110,15 @@ type FieldSchema struct {
 
 // Factory creates a Store from a flat config map.
 type Factory func(cfg map[string]string) (Store, error)
+
+// beijing is China Standard Time (UTC+8, no DST). Built as a fixed zone
+// so scheduled-release formatting never depends on the host having the
+// IANA tzdata database installed.
+var beijing = time.FixedZone("UTC+8", 8*60*60)
+
+// BeijingLocalTime renders t as "2006-01-02 15:04:05" in Beijing time.
+// Used by stores whose scheduled-release field is a local datetime
+// string with no timezone of its own (oppo, vivo, samsung).
+func BeijingLocalTime(t time.Time) string {
+	return t.In(beijing).Format("2006-01-02 15:04:05")
+}

--- a/pkg/store/tencent/tencent.go
+++ b/pkg/store/tencent/tencent.go
@@ -34,8 +34,9 @@ var cosClient = &http.Client{}
 
 func init() {
 	store.Register("tencent", store.ConfigSchema{
-		Name:       "tencent",
-		ConsoleURL: "https://wikinew.open.qq.com/index.html#/iwiki/4015262492",
+		Name:                     "tencent",
+		ConsoleURL:               "https://wikinew.open.qq.com/index.html#/iwiki/4015262492",
+		SupportsScheduledRelease: true,
 		Fields: []store.FieldSchema{
 			{Key: "user_id", Required: true, Desc: "Tencent open platform developer user ID"},
 			{Key: "access_secret", Required: true, Desc: "API access secret (账户管理 → API 发布接口 → 申请开通)"},
@@ -305,6 +306,14 @@ func (s *Store) updateApp(pkg, appID string, req *store.UploadRequest, apkSerial
 	params.Set("pkg_name", pkg)
 	params.Set("app_id", appID)
 	params.Set("deploy_type", "1") // publish immediately after approval
+	if req.ReleaseTime != nil {
+		// Scheduled release (定时发布): deploy_type 2 = 定时发布, with
+		// deploy_time as a Unix *second* timestamp (absolute instant;
+		// Tencent documents it as Beijing time but epoch seconds are
+		// timezone-independent).
+		params.Set("deploy_type", "2")
+		params.Set("deploy_time", strconv.FormatInt(req.ReleaseTime.Unix(), 10))
+	}
 
 	// APK files
 	switch {
@@ -487,14 +496,14 @@ func calcFileMD5(path string) (string, error) {
 
 // diagnose is registered with `apkgo doctor`. Two probes:
 //
-//   app-detail   — calls /query_app_detail to verify HMAC-SHA256 sign +
-//                  auth path AND that the app_id/pkg_name combo binds
-//                  correctly under this developer (ret 1000009 if not).
-//                  Reports app_name + category for sanity.
-//   audit-status — calls /query_app_update_status to surface the most
-//                  recent submission's audit state (auditing / approved /
-//                  rejected / withdrawn) so the operator knows whether
-//                  the slot is free for a new upload.
+//	app-detail   — calls /query_app_detail to verify HMAC-SHA256 sign +
+//	               auth path AND that the app_id/pkg_name combo binds
+//	               correctly under this developer (ret 1000009 if not).
+//	               Reports app_name + category for sanity.
+//	audit-status — calls /query_app_update_status to surface the most
+//	               recent submission's audit state (auditing / approved /
+//	               rejected / withdrawn) so the operator knows whether
+//	               the slot is free for a new upload.
 func diagnose(ctx context.Context, cfg map[string]string, hint store.DiagnoseHint) []store.Probe {
 	probes := make([]store.Probe, 0, 2)
 

--- a/pkg/store/vivo/vivo.go
+++ b/pkg/store/vivo/vivo.go
@@ -29,8 +29,9 @@ const vivoBaseURL = "https://developer-api.vivo.com.cn/router/rest"
 
 func init() {
 	store.Register("vivo", store.ConfigSchema{
-		Name:       "vivo",
-		ConsoleURL: "https://dev.vivo.com.cn/documentCenter/doc/326",
+		Name:                     "vivo",
+		ConsoleURL:               "https://dev.vivo.com.cn/documentCenter/doc/326",
+		SupportsScheduledRelease: true,
 		Fields: []store.FieldSchema{
 			{Key: "access_key", Required: true, Desc: "vivo open platform access key"},
 			{Key: "access_secret", Required: true, Desc: "vivo open platform access secret"},
@@ -83,6 +84,12 @@ func (s *Store) upload(_ context.Context, req *store.UploadRequest) error {
 		"onlineType":       "1",
 		"updateDesc":       req.ReleaseNotes,
 		"compatibleDevice": "2",
+	}
+	if req.ReleaseTime != nil {
+		// Scheduled release (定时上架): onlineType 2 = 定时上架, with
+		// scheOnlineTime as a Beijing-local datetime string.
+		updateReq["onlineType"] = "2"
+		updateReq["scheOnlineTime"] = store.BeijingLocalTime(*req.ReleaseTime)
 	}
 
 	// Pre-declare combined upload bytes so the bar is stable across
@@ -243,8 +250,8 @@ func (s *Store) updateApp(method string, bizParams map[string]string) error {
 // vivo splits errors into two layers:
 //   - Code: gateway-level result (0 = the call reached the service)
 //   - SubCode: business-level error code; non-empty SubCode means the
-//             call was accepted by the gateway but the service rejected
-//             it (e.g. SubCode=15042 "请上传与历史签名一致的APK包").
+//     call was accepted by the gateway but the service rejected
+//     it (e.g. SubCode=15042 "请上传与历史签名一致的APK包").
 //
 // A response with Code=0 and a non-empty SubCode is therefore NOT a
 // success — the original code only checking Code led to real upload
@@ -388,12 +395,12 @@ func (s *Store) queryApp(packageName string) (*appDetails, error) {
 
 // diagnose is registered with `apkgo doctor`. Single probe:
 //
-//   app-info — calls /router/rest with method=app.query.details, which
-//              both validates the HMAC-SHA256 signature server-side and
-//              checks that the package exists under this developer
-//              account. A package-name hint is required since vivo has
-//              no separate "verify credentials" endpoint to probe with
-//              an empty body.
+//	app-info — calls /router/rest with method=app.query.details, which
+//	           both validates the HMAC-SHA256 signature server-side and
+//	           checks that the package exists under this developer
+//	           account. A package-name hint is required since vivo has
+//	           no separate "verify credentials" endpoint to probe with
+//	           an empty body.
 func diagnose(ctx context.Context, cfg map[string]string, hint store.DiagnoseHint) []store.Probe {
 	probes := make([]store.Probe, 0, 1)
 

--- a/pkg/store/xiaomi/xiaomi.go
+++ b/pkg/store/xiaomi/xiaomi.go
@@ -38,8 +38,9 @@ const xiaomiBaseURL = "https://api.developer.xiaomi.com/devupload"
 
 func init() {
 	store.Register("xiaomi", store.ConfigSchema{
-		Name:       "xiaomi",
-		ConsoleURL: "https://dev.mi.com/xiaomihyperos/documentation/detail?pId=1134",
+		Name:                     "xiaomi",
+		ConsoleURL:               "https://dev.mi.com/xiaomihyperos/documentation/detail?pId=1134",
+		SupportsScheduledRelease: true,
 		Fields: []store.FieldSchema{
 			{Key: "email", Required: true, Desc: "Xiaomi developer account email (mapped to userName)"},
 			{Key: "private_key", Required: true, Desc: "Xiaomi API private key (the value the upload SDK calls 'password')"},
@@ -172,6 +173,11 @@ func (s *Store) push(synchroType int, req *store.UploadRequest, iconPath string,
 		"appName":     req.AppName,
 		"packageName": req.PackageName,
 		"updateDesc":  req.ReleaseNotes,
+	}
+	if req.ReleaseTime != nil {
+		// Scheduled release (定时上线): onlineTime is a Unix millisecond
+		// timestamp (absolute instant, timezone-independent).
+		appInfo["onlineTime"] = req.ReleaseTime.UnixMilli()
 	}
 
 	files := map[string]string{
@@ -428,7 +434,7 @@ type packageInfo struct {
 //
 //  1. cert  — public-key certificate is loadable, RSA, and not expired
 //  2. query — /dev/query accepts the SIG (proves email + private_key + cert
-//             all line up) and returns the stored package info if any
+//     all line up) and returns the stored package info if any
 //
 // Probe 2 needs a package-name hint and is reported as skipped without it,
 // since /dev/query requires `packageName`.


### PR DESCRIPTION
## What

Adds a global `--release-time` flag to `apkgo upload` that schedules a **timed release (定时发布)** at a given RFC3339 time, instead of the default "go live immediately after review".

```bash
apkgo upload -f app.apk --release-time 2026-06-20T10:00:00+08:00
```

## How

`--release-time` (RFC3339, must carry a timezone offset and be in the future) → `apkgo.Job.ReleaseTime` → `store.UploadRequest.ReleaseTime *time.Time`. Each store maps it to its own API field/format at its publish call site:

| Store | Trigger | Time field | Format |
|---|---|---|---|
| huawei | (releaseType stays 1) | `releaseTime` (query) | UTC w/ offset, e.g. `…+0800` |
| honor | `releaseType=2` | `releaseTime` | UTC w/ offset |
| xiaomi | — | `appInfo.onlineTime` | Unix **millis** |
| tencent | `deploy_type=2` | `deploy_time` | Unix **seconds** |
| oppo | `online_type=2` | `sche_online_time` | Beijing local |
| vivo | `onlineType=2` | `scheOnlineTime` | Beijing local |
| samsung | `publicationType=02` | `startPublicationDate` | Beijing local |

- Epoch-based stores (xiaomi/tencent) use the absolute instant; oppo/vivo/samsung carry no timezone in their field, so the time is rendered in Beijing (UTC+8) via `store.BeijingLocalTime` (fixed zone — no tzdata dependency).
- Stores that **can't** schedule (googleplay, pgyer, fir, script) log a warning and release immediately — they are not failed.
- Capability is declared per store via `ConfigSchema.SupportsScheduledRelease`, surfaced in `apkgo stores` as `supports_scheduled_release`.
- A `nil` `ReleaseTime` keeps the existing immediate-release behaviour **fully unchanged**.

## Issue

Addresses #15 (定时发布 / choosing the public release time).

The comment thread on #15 also asks for a second, **separate** mode — *manual* release after approval ("审核通过后再手动放开"). That is **not** in this PR and would make a good follow-up, so I've referenced rather than auto-closed #15 — close it if you consider the scheduled-release part sufficient.

Related: #10 (分阶段发布 / phased rollout) is a different feature that these same store APIs also support (huawei `releaseType=3`, vivo/oppo/xiaomi/samsung staged endpoints, Google Play `userFraction`) — not implemented here.

## Verification

- `go build ./...`, `go vet ./...`, `go test -short ./...` — all green.
- New `pkg/store/scheduled_test.go`: Beijing-time conversion (cross-timezone, cross-date) + capability lookup (incl. `type.instance` resolution).
- CLI checked: flag appears in `--help`; bad format rejected with a clear message; `apkgo stores` reports exactly the 7 supporting stores.

## Caveats (honest)

- **No end-to-end test against real stores** — there are no upload credentials / HTTP-mock harness here, so per-store wire formats follow each store's official API docs (read June 2026) and are covered by code review + unit tests, not a live submission.
- **Samsung timezone**: `startPublicationDate` has no documented timezone; it's rendered as Beijing time here. Worth confirming against one real scheduled submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
