### PR TITLE
feat: pull APK from -f URL for huawei/honor/vivo (download mode)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,25 @@ immediately. Each store maps the instant to its own field/format
 internally — epoch-based stores use the absolute instant; oppo/vivo/samsung
 render it in Beijing time (UTC+8).
 
+### Download mode (URL pass-through)
+
+When `-f` (or `--file64`) is a **public** http(s) URL, stores that support
+it pull the APK straight from your OSS instead of apkgo re-uploading the
+bytes — faster, especially for large APKs or cloud runs. Supported stores:
+**huawei, honor, vivo** (see `supports_url_push` in `apkgo stores`); the
+others always upload. apkgo still fetches the APK once locally for metadata.
+
+- The URL must be reachable **without auth** (the store GETs it directly).
+  Passing `--fetch-header` (auth) makes apkgo upload instead of passing the
+  URL through.
+- These flows are **asynchronous**: the store downloads in the background
+  and apkgo polls until it finishes. Each store has its own download
+  interface (huawei `app-package-file/by-url`, honor `upload-by-url`, vivo
+  `app.update.app` + `app.query.task.status`).
+- **honor** throttles its status poll to ~once/3min, so it only URL-pushes
+  when the APK is at least `url_push_min_mb` MB (default 100); smaller APKs
+  upload directly. huawei and vivo URL-push whenever the source is a URL.
+
 ## Supported stores
 
 huawei, xiaomi, oppo, vivo, honor, tencent, googleplay, samsung, pgyer, fir, script

--- a/pkg/apkgo/job.go
+++ b/pkg/apkgo/job.go
@@ -265,6 +265,23 @@ func Run(ctx context.Context, job Job) (*Result, error) {
 	}
 	pm.Start(info, storeNames)
 
+	// URL pass-through (download mode): when the input was a public
+	// http(s) URL fetched without auth headers, hand the original URL to
+	// stores that can pull it themselves (huawei/honor/vivo) so they
+	// download from your OSS instead of apkgo re-uploading the bytes. If
+	// auth headers were needed, the store couldn't GET it anonymously, so
+	// we don't pass it and those stores upload the local copy instead. We
+	// still fetched a local copy above for APK metadata either way.
+	var sourceURL, source64URL string
+	if len(job.FetchHeaders) == 0 {
+		if httpx.IsURL(job.APKFile) {
+			sourceURL = job.APKFile
+		}
+		if httpx.IsURL(job.APKFile64) {
+			source64URL = job.APKFile64
+		}
+	}
+
 	req := &store.UploadRequest{
 		FilePath:     apkPath,
 		File64Path:   apk64Path,
@@ -274,6 +291,8 @@ func Run(ctx context.Context, job Job) (*Result, error) {
 		VersionName:  info.VersionName,
 		ReleaseNotes: notes,
 		ReleaseTime:  releaseTime,
+		SourceURL:    sourceURL,
+		Source64URL:  source64URL,
 	}
 
 	hookEnv := map[string]string{

--- a/pkg/store/honor/honor.go
+++ b/pkg/store/honor/honor.go
@@ -27,10 +27,12 @@ func init() {
 		Name:                     "honor",
 		ConsoleURL:               "https://developer.honor.com/cn/doc/guides/101360",
 		SupportsScheduledRelease: true,
+		SupportsURLPush:          true,
 		Fields: []store.FieldSchema{
 			{Key: "client_id", Required: true, Desc: "Honor developer API client ID"},
 			{Key: "client_secret", Required: true, Desc: "Honor developer API client secret"},
 			{Key: "app_id", Required: false, Desc: "Honor app ID (auto-detected from package name if omitted)"},
+			{Key: "url_push_min_mb", Required: false, Desc: "min APK size (MB) to pull from -f URL instead of uploading; honor throttles its download-status poll to ~3min so small files upload faster (default 100)"},
 		},
 	}, func(cfg map[string]string) (store.Store, error) {
 		return New(cfg)
@@ -70,10 +72,21 @@ const (
 // get-file-upload-url / update-file-info requests.
 const fileTypeAPK = 100
 
+// Download-mode (upload-by-url) constants. Honor pulls the package from a
+// public URL asynchronously and rate-limits status queries to ~once/3min,
+// so direct upload is faster for small APKs — we only URL-push above the
+// size gate, and poll no more often than Honor allows.
+const (
+	honorUploadDone        = 0 // upload-by-url status: 0=成功, 1=待上传, 2=上传中
+	honorURLPushDefaultMB  = 100
+	honorURLPushPollPeriod = 3 * time.Minute
+)
+
 type Store struct {
-	client      *resty.Client // bound to publishBase with Bearer auth
-	accessToken string        // kept separately so we can pass it on the signed upload URL, which belongs to a different host
-	configAppID string        // optional; when set, skips the get-app-id lookup
+	client          *resty.Client // bound to publishBase with Bearer auth
+	accessToken     string        // kept separately so we can pass it on the signed upload URL, which belongs to a different host
+	configAppID     string        // optional; when set, skips the get-app-id lookup
+	urlPushMinBytes int64         // APK must be at least this big to pull from -f URL; 0 = default
 }
 
 func New(cfg map[string]string) (*Store, error) {
@@ -93,7 +106,19 @@ func New(cfg map[string]string) (*Store, error) {
 		SetAuthToken(token).
 		SetHeader("Content-Type", "application/json")
 
-	return &Store{client: client, accessToken: token, configAppID: cfg["app_id"]}, nil
+	minMB := honorURLPushDefaultMB
+	if v := strings.TrimSpace(cfg["url_push_min_mb"]); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			minMB = n
+		}
+	}
+
+	return &Store{
+		client:          client,
+		accessToken:     token,
+		configAppID:     cfg["app_id"],
+		urlPushMinBytes: int64(minMB) << 20,
+	}, nil
 }
 
 func (s *Store) Name() string { return "honor" }
@@ -127,8 +152,15 @@ func (s *Store) upload(ctx context.Context, req *store.UploadRequest) error {
 		return fmt.Errorf("get app detail: %w", err)
 	}
 
-	// Upload phase: get signed URL, PUT/POST the APK, bind by objectId.
-	if err := s.uploadAPK(ctx, appID, req.FilePath, rep); err != nil {
+	// Get the APK to Honor. When -f is a public URL and the APK is large
+	// enough to be worth Honor's async download (it throttles status polls
+	// to ~once/3min, so small files upload faster directly), hand Honor the
+	// URL and let it pull the binary; otherwise upload the bytes.
+	if req.SourceURL != "" && s.shouldURLPush(req.FilePath) {
+		if err := s.uploadByURL(ctx, appID, req.SourceURL, req.FilePath, rep); err != nil {
+			return fmt.Errorf("upload apk by url: %w", err)
+		}
+	} else if err := s.uploadAPK(ctx, appID, req.FilePath, rep); err != nil {
 		return fmt.Errorf("upload apk: %w", err)
 	}
 
@@ -357,12 +389,117 @@ func (s *Store) uploadAPK(ctx context.Context, appID, apkPath string, rep progre
 
 	// Step 4: tell honor that objectId is the new binary for this app.
 	rep.Phase("publishing")
+	return s.bindFile(ctx, appID, upload.ObjectID)
+}
+
+// shouldURLPush reports whether the APK is large enough that Honor's async
+// download-from-URL (with its ~3min status-poll floor) beats a direct
+// upload. Below the threshold, uploading the bytes is faster. A stat
+// failure falls back to the upload path.
+func (s *Store) shouldURLPush(apkPath string) bool {
+	min := s.urlPushMinBytes
+	if min <= 0 {
+		min = int64(honorURLPushDefaultMB) << 20
+	}
+	fi, err := os.Stat(apkPath)
+	if err != nil {
+		return false
+	}
+	return fi.Size() >= min
+}
+
+// uploadByURL hands Honor a public download URL (upload-by-url) instead of
+// uploading the APK bytes. Honor downloads the file on its own side
+// (async); we poll until it reports the upload finished, then bind the
+// objectId exactly as the upload path does. The URL must be HTTPS, public
+// and unauthenticated — Honor GETs it directly.
+func (s *Store) uploadByURL(ctx context.Context, appID, sourceURL, apkPath string, rep progress.Reporter) error {
+	rep.Phase("hashing")
+	size, sum, err := statAndSha256(apkPath)
+	if err != nil {
+		return fmt.Errorf("hash apk: %w", err)
+	}
+	fileName := filepath.Base(apkPath)
+
+	// Step 1: enqueue the download task (type=1).
+	rep.Phase("url push")
+	objectID, status, err := s.urlPushTask(ctx, appID, map[string]any{
+		"type": 1,
+		"uploadList": []map[string]any{{
+			"fileName":      fileName,
+			"fileType":      fileTypeAPK,
+			"fileSize":      size,
+			"fileSha256":    sum,
+			"fileUploadUrl": sourceURL,
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("create url upload task: %w", err)
+	}
+
+	// Step 2: poll until Honor finishes downloading (status 0). Honor
+	// rate-limits status queries, so wait ~3min between checks; ctx
+	// (the run timeout) bounds the wait.
+	for status != honorUploadDone {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for honor to download package from url: %w", ctx.Err())
+		case <-time.After(honorURLPushPollPeriod):
+		}
+		_, status, err = s.urlPushTask(ctx, appID, map[string]any{
+			"type":       2,
+			"objectList": []map[string]any{{"objectId": objectID}},
+		})
+		if err != nil {
+			return fmt.Errorf("query url upload status: %w", err)
+		}
+	}
+
+	// Step 3: bind the objectId to the app, same as the upload path.
+	rep.Phase("publishing")
+	return s.bindFile(ctx, appID, objectID)
+}
+
+// urlPushTask POSTs to upload-by-url and returns the first object's id and
+// status. Serves both the create (type=1) and status-query (type=2) calls.
+func (s *Store) urlPushTask(ctx context.Context, appID string, body map[string]any) (objectID int64, status int, err error) {
+	var resp struct {
+		honorResp
+		Data []struct {
+			ObjectID int64 `json:"objectId"`
+			Status   int   `json:"status"`
+		} `json:"data"`
+	}
+	httpResp, err := s.client.R().
+		SetContext(ctx).
+		SetQueryParam("appId", appID).
+		SetBody(body).
+		SetResult(&resp).
+		Post("/openapi/v1/publish/upload-by-url")
+	if err != nil {
+		return 0, 0, err
+	}
+	if httpResp.IsError() {
+		return 0, 0, fmt.Errorf("http %d: %s", httpResp.StatusCode(), truncateBody(httpResp.String()))
+	}
+	if resp.Code != 0 {
+		return 0, 0, store.Categorize(classifyHonor(resp.Code), fmt.Errorf("[%d] %s", resp.Code, resp.text()))
+	}
+	if len(resp.Data) == 0 {
+		return 0, 0, fmt.Errorf("empty upload-by-url response")
+	}
+	return resp.Data[0].ObjectID, resp.Data[0].Status, nil
+}
+
+// bindFile tells Honor that objectId is the new binary for the app's draft
+// version (update-file-info). Shared by the upload and URL-push paths.
+func (s *Store) bindFile(ctx context.Context, appID string, objectID int64) error {
 	var bindResp honorResp
 	bindHTTP, err := s.client.R().
 		SetContext(ctx).
 		SetQueryParam("appId", appID).
 		SetBody(map[string]any{
-			"bindingFileList": []map[string]any{{"objectId": upload.ObjectID}},
+			"bindingFileList": []map[string]any{{"objectId": objectID}},
 		}).
 		SetResult(&bindResp).
 		Post("/openapi/v1/publish/update-file-info")

--- a/pkg/store/honor/honor_test.go
+++ b/pkg/store/honor/honor_test.go
@@ -1,0 +1,45 @@
+package honor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestShouldURLPush covers honor's size gate: it only hands the APK to
+// honor's async download-from-URL (which throttles status polls to
+// ~3min) when the file is at least urlPushMinBytes; smaller files upload
+// faster directly. A stat failure must fall back to the upload path.
+func TestShouldURLPush(t *testing.T) {
+	dir := t.TempDir()
+	mkfile := func(name string, size int) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, make([]byte, size), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	small := mkfile("small.apk", 10)
+	big := mkfile("big.apk", 200)
+
+	cases := []struct {
+		name     string
+		minBytes int64
+		path     string
+		want     bool
+	}{
+		{"above threshold", 100, big, true},
+		{"below threshold", 100, small, false},
+		{"equal threshold is inclusive", 200, big, true},
+		{"zero falls back to 100MB default", 0, big, false}, // 200 bytes < 100MiB
+		{"missing file falls back to upload", 100, filepath.Join(dir, "nope.apk"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := &Store{urlPushMinBytes: c.minBytes}
+			if got := s.shouldURLPush(c.path); got != c.want {
+				t.Errorf("shouldURLPush(min=%d) = %v, want %v", c.minBytes, got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/store/huawei/huawei.go
+++ b/pkg/store/huawei/huawei.go
@@ -23,6 +23,7 @@ func init() {
 		Name:                     "huawei",
 		ConsoleURL:               "https://developer.huawei.com/consumer/cn/doc/AppGallery-connect-Guides/agcapi-getstarted-0000001111845114#section1785535363715",
 		SupportsScheduledRelease: true,
+		SupportsURLPush:          true,
 		Fields: []store.FieldSchema{
 			{Key: "service_account", Required: false, Desc: "Service Account credential JSON (raw or base64); recommended"},
 			{Key: "service_account_file", Required: false, Desc: "Path to Service Account credential JSON file"},
@@ -124,8 +125,17 @@ func (s *Store) upload(ctx context.Context, req *store.UploadRequest) error {
 		}
 	}
 
-	// Upload APK
-	if err := s.uploadAPK(appID, req.FilePath, rep); err != nil {
+	// Get the APK to Huawei. When -f was a public URL, hand Huawei the URL
+	// and let it download the package itself (skips re-uploading the
+	// bytes); otherwise upload the local file. The by-url path is async —
+	// pollAndSubmit below already retries while Huawei is still parsing,
+	// which absorbs the download wait.
+	if req.SourceURL != "" {
+		rep.Phase("submitting url")
+		if err := s.submitPackageByURL(appID, req.SourceURL, req); err != nil {
+			return fmt.Errorf("submit package by url: %w", err)
+		}
+	} else if err := s.uploadAPK(appID, req.FilePath, rep); err != nil {
 		return fmt.Errorf("upload apk: %w", err)
 	}
 
@@ -323,6 +333,54 @@ func (s *Store) uploadAPK(appID, apkPath string, rep progress.Reporter) error {
 	}
 	if updateResp.Ret.Code != 0 {
 		return fmt.Errorf("update file info: [%d] %s", updateResp.Ret.Code, updateResp.Ret.text())
+	}
+	return nil
+}
+
+// submitPackageByURL hands Huawei a developer-hosted download URL
+// (POST /publish/v2/app-package-file/by-url) instead of uploading the APK
+// bytes. Huawei downloads the package from the URL on its own side and
+// associates it with the app's draft version — no fileDestUrl is returned
+// to bind, so unlike the upload path there is no app-file-info step. The
+// download is asynchronous: this call only enqueues it (ret.code 0), and
+// the subsequent pollAndSubmit absorbs the wait via its parsing-retry.
+// The URL must be publicly GET-able (Huawei fetches it unauthenticated).
+func (s *Store) submitPackageByURL(appID, sourceURL string, req *store.UploadRequest) error {
+	// downloadFileName must carry the real suffix; derive it from the URL
+	// path, falling back to "<package>.apk".
+	name := sourceURL
+	if i := strings.IndexAny(name, "?#"); i >= 0 {
+		name = name[:i]
+	}
+	if i := strings.LastIndexByte(name, '/'); i >= 0 {
+		name = name[i+1:]
+	}
+	if name == "" {
+		name = req.PackageName + ".apk"
+	}
+	requestID := fmt.Sprintf("apkgo-%s-%d-%d", req.PackageName, req.VersionCode, time.Now().UnixNano())
+
+	var resp struct {
+		Ret retInfo `json:"ret"`
+	}
+	httpResp, err := s.client.R().
+		SetQueryParams(map[string]string{"appId": appID}).
+		SetBody(map[string]any{
+			"downloadUrl":      sourceURL,
+			"downloadFileName": name,
+			"requestId":        requestID,
+			"packageType":      1, // 1 = APK
+		}).
+		SetResult(&resp).
+		Post("/api/publish/v2/app-package-file/by-url")
+	if err != nil {
+		return err
+	}
+	if httpResp.IsError() {
+		return fmt.Errorf("http %d: %s", httpResp.StatusCode(), strings.TrimSpace(string(httpResp.Body())))
+	}
+	if resp.Ret.Code != 0 {
+		return fmt.Errorf("[%d] %s", resp.Ret.Code, resp.Ret.text())
 	}
 	return nil
 }

--- a/pkg/store/registry.go
+++ b/pkg/store/registry.go
@@ -89,3 +89,16 @@ func SupportsScheduledRelease(name string) bool {
 	}
 	return ok && e.schema.SupportsScheduledRelease
 }
+
+// SupportsURLPush reports whether the named store declared download-mode
+// (pull-from-URL) support in its ConfigSchema. Same "type.instance"
+// resolution as AcceptsAAB. Unknown names return false.
+func SupportsURLPush(name string) bool {
+	e, ok := registry[name]
+	if !ok {
+		if dot := strings.Index(name, "."); dot > 0 {
+			e, ok = registry[name[:dot]]
+		}
+	}
+	return ok && e.schema.SupportsURLPush
+}

--- a/pkg/store/scheduled_test.go
+++ b/pkg/store/scheduled_test.go
@@ -64,3 +64,32 @@ func TestSupportsScheduledRelease(t *testing.T) {
 		}
 	}
 }
+
+// TestSupportsURLPush mirrors TestSupportsScheduledRelease for the
+// download-mode (pull-from-URL) capability flag that apkgo.Run uses to
+// decide whether a store can take a developer-hosted URL instead of an
+// uploaded binary.
+func TestSupportsURLPush(t *testing.T) {
+	store.Register("test-urlpush-yes", store.ConfigSchema{
+		Name:            "test-urlpush-yes",
+		SupportsURLPush: true,
+	}, func(map[string]string) (store.Store, error) { return nil, nil })
+	store.Register("test-urlpush-no", store.ConfigSchema{
+		Name: "test-urlpush-no",
+	}, func(map[string]string) (store.Store, error) { return nil, nil })
+
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"test-urlpush-yes", true},
+		{"test-urlpush-no", false},
+		{"test-urlpush-yes.instance", true}, // type.instance resolves to base type
+		{"unregistered", false},
+	}
+	for _, c := range cases {
+		if got := store.SupportsURLPush(c.name); got != c.want {
+			t.Errorf("SupportsURLPush(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -33,6 +33,18 @@ type UploadRequest struct {
 	// nil = immediate (the default, unchanged behaviour).
 	ReleaseTime *time.Time `json:",omitempty"`
 
+	// SourceURL / Source64URL carry the original public http(s) URL the
+	// APK (and optional 64-bit APK) were given as, when no auth headers
+	// were needed to fetch them. Stores that support "download mode"
+	// (huawei, honor, vivo — see SupportsURLPush) hand this URL to the
+	// store so it pulls the binary from your OSS instead of apkgo
+	// re-uploading the bytes. Empty when the input was a local file or
+	// required --fetch-header auth (the store must be able to GET it
+	// anonymously). FilePath is always set regardless, so stores that
+	// can't (or choose not to) URL-push still upload the local copy.
+	SourceURL   string `json:",omitempty"`
+	Source64URL string `json:",omitempty"`
+
 	// Progress receives phase and byte-count events during upload.
 	// May be nil; stores must use progress.Safe() to guard against that.
 	// Tagged json:"-" so it's excluded when script-store marshals the
@@ -100,6 +112,11 @@ type ConfigSchema struct {
 	// also drives the warning when --release-time targets a store that
 	// can't honor it.
 	SupportsScheduledRelease bool `json:"supports_scheduled_release,omitempty"`
+	// SupportsURLPush is true if the store's API can pull the APK from a
+	// developer-hosted URL (download mode) instead of requiring a byte
+	// upload. apkgo uses it to skip re-uploading when -f is a public URL.
+	// Surfaced by `apkgo stores`.
+	SupportsURLPush bool `json:"supports_url_push,omitempty"`
 }
 
 type FieldSchema struct {

--- a/pkg/store/vivo/vivo.go
+++ b/pkg/store/vivo/vivo.go
@@ -32,6 +32,7 @@ func init() {
 		Name:                     "vivo",
 		ConsoleURL:               "https://dev.vivo.com.cn/documentCenter/doc/326",
 		SupportsScheduledRelease: true,
+		SupportsURLPush:          true,
 		Fields: []store.FieldSchema{
 			{Key: "access_key", Required: true, Desc: "vivo open platform access key"},
 			{Key: "access_secret", Required: true, Desc: "vivo open platform access secret"},
@@ -75,7 +76,7 @@ func (s *Store) Upload(ctx context.Context, req *store.UploadRequest) *store.Upl
 	return store.NewResult(s.Name(), start)
 }
 
-func (s *Store) upload(_ context.Context, req *store.UploadRequest) error {
+func (s *Store) upload(ctx context.Context, req *store.UploadRequest) error {
 	rep := progress.Safe(req.Progress)
 
 	updateReq := map[string]string{
@@ -90,6 +91,13 @@ func (s *Store) upload(_ context.Context, req *store.UploadRequest) error {
 		// scheOnlineTime as a Beijing-local datetime string.
 		updateReq["onlineType"] = "2"
 		updateReq["scheOnlineTime"] = store.BeijingLocalTime(*req.ReleaseTime)
+	}
+
+	// URL pass-through (download mode): when -f (and --file64 for split)
+	// are public URLs, hand vivo the download addresses and let it pull
+	// the APKs itself (async), instead of uploading the bytes.
+	if pushed, err := s.maybeURLPush(ctx, req, updateReq, rep); pushed {
+		return err
 	}
 
 	// Pre-declare combined upload bytes so the bar is stable across
@@ -126,6 +134,118 @@ func (s *Store) upload(_ context.Context, req *store.UploadRequest) error {
 	updateReq["fileMd5"] = resp.FileMD5
 	rep.Phase("publishing")
 	return s.updateApp("app.sync.update.app", updateReq)
+}
+
+// vivoTaskPollPeriod is how often we poll vivo's async task-status while it
+// downloads the APK(s) from the developer URL. vivo documents no rate
+// limit here, so a short interval is fine.
+const vivoTaskPollPeriod = 15 * time.Second
+
+// maybeURLPush implements vivo's download mode. When the APK(s) came in as
+// public URLs it hands vivo the download addresses (the app.update.* async
+// interfaces) and polls the task status, instead of uploading the bytes.
+// Returns (true, err) when it owns the publish, or (false, nil) to fall
+// through to the upload path (e.g. local file, or split with only one URL).
+func (s *Store) maybeURLPush(ctx context.Context, req *store.UploadRequest, bizParams map[string]string, rep progress.Reporter) (bool, error) {
+	switch {
+	case req.File64Path != "":
+		// Split arch: vivo's subpackage download needs BOTH public URLs;
+		// if either side is a local file, fall back to the upload path.
+		if req.SourceURL == "" || req.Source64URL == "" {
+			return false, nil
+		}
+		md32, err := fileMD5(req.FilePath)
+		if err != nil {
+			return true, fmt.Errorf("md5 32-bit apk: %w", err)
+		}
+		md64, err := fileMD5(req.File64Path)
+		if err != nil {
+			return true, fmt.Errorf("md5 64-bit apk: %w", err)
+		}
+		// FilePath is the 32-bit (-f), File64Path the 64-bit (--file64);
+		// vivo names the 64-bit md5 field apkMd5 and the 32-bit apk32Md5.
+		bizParams["apkUrl32"] = req.SourceURL
+		bizParams["apk32Md5"] = md32
+		bizParams["apkUrl64"] = req.Source64URL
+		bizParams["apkMd5"] = md64
+		rep.Phase("url push")
+		if err := s.updateApp("app.update.subpackage.app", bizParams); err != nil {
+			return true, err
+		}
+	case req.SourceURL != "":
+		md, err := fileMD5(req.FilePath)
+		if err != nil {
+			return true, fmt.Errorf("md5 apk: %w", err)
+		}
+		bizParams["apkUrl"] = req.SourceURL
+		bizParams["apkMd5"] = md
+		rep.Phase("url push")
+		if err := s.updateApp("app.update.app", bizParams); err != nil {
+			return true, err
+		}
+	default:
+		return false, nil
+	}
+
+	// vivo processes the download asynchronously; poll until it finishes.
+	rep.Phase("publishing")
+	return true, s.pollTaskStatus(ctx, req.PackageName)
+}
+
+// pollTaskStatus polls app.query.task.status until vivo's async
+// download-update resolves (status 3 = success, 4 = failure).
+func (s *Store) pollTaskStatus(ctx context.Context, packageName string) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for vivo to download package: %w", ctx.Err())
+		case <-time.After(vivoTaskPollPeriod):
+		}
+		status, reason, err := s.queryTaskStatus(packageName)
+		if err != nil {
+			return err
+		}
+		switch status {
+		case 3: // 处理成功
+			return nil
+		case 4: // 处理失败
+			if reason == "" {
+				reason = "vivo reported the download task failed"
+			}
+			return store.Categorize(store.CategoryUnknown, fmt.Errorf("vivo download task failed: %s", reason))
+		}
+		// 1 待处理 / 2 处理中 → keep waiting
+	}
+}
+
+// queryTaskStatus calls app.query.task.status for an update task
+// (packetType 0) and returns the task status and any error reason.
+func (s *Store) queryTaskStatus(packageName string) (status int, reason string, err error) {
+	params := s.signParams("app.query.task.status", map[string]string{
+		"packageName": packageName,
+		"packetType":  "0", // 0 = update package
+	})
+	httpResp, err := s.client.R().SetQueryParams(params).Post("")
+	if err != nil {
+		return 0, "", err
+	}
+	body := httpResp.Body()
+	var resp struct {
+		envelope
+		Data struct {
+			Status      int    `json:"status"`
+			ErrorReason string `json:"errorReason"`
+		} `json:"data"`
+	}
+	if jerr := json.Unmarshal(body, &resp); jerr != nil {
+		return 0, "", fmt.Errorf("decode task status (HTTP %d): %v: %s",
+			httpResp.StatusCode(), jerr, truncateBody(string(body)))
+	}
+	if resp.failed() {
+		return 0, "", store.Categorize(classifyVivo(resp.SubCode),
+			fmt.Errorf("[%s] %s", resp.errorCode(), resp.text()))
+	}
+	return resp.Data.Status, resp.Data.ErrorReason, nil
 }
 
 // sumFileSizes totals the byte sizes of the given paths. Empty paths are ignored.


### PR DESCRIPTION
## What

When `-f` (or `--file64`) is a **public** http(s) URL, stores that support **download mode** now pull the APK straight from your OSS instead of apkgo re-uploading the bytes — faster, especially for large APKs or cloud runs where apkgo's uplink is the bottleneck.

```bash
apkgo upload -f https://oss.example.com/app-v1.2.0.apk --store huawei,honor,vivo
```

## How

`-f` URL (no `--fetch-header` auth) → `UploadRequest.SourceURL` / `Source64URL` → each supporting store hands the URL to its download interface:

| Store | When | Interface | Async handling |
|---|---|---|---|
| **huawei** | source is a URL | `POST /publish/v2/app-package-file/by-url` (`downloadUrl`+`downloadFileName`+`requestId`+`packageType:1`) | reuse existing `pollAndSubmit` — its parsing-retry absorbs the download wait |
| **honor** | source is a URL **and** APK ≥ `url_push_min_mb` | `upload-by-url` `type=1` create → `type=2` poll → reuse `update-file-info` bind + `submit-audit` | poll ~every 3min (honor rate-limits status queries) |
| **vivo** | source is a URL (split needs both) | `app.update.app` / `app.update.subpackage.app` (apkUrl+md5) | poll `app.query.task.status` until status 3/4 |

- **Gating** (in `apkgo.Run`): a store gets `SourceURL` only when the input was a public http(s) URL fetched with **no** `--fetch-header` auth (the store must GET it anonymously). Local files / authed URLs → existing upload path, unchanged. apkgo still fetches the APK once locally for metadata (and honor/vivo md5+sha256).
- **honor size gate**: honor's download-status poll is throttled to ~once/3min, so for small APKs a direct upload is faster. It only URL-pushes above `url_push_min_mb` (new honor config field, default 100). huawei/vivo URL-push whenever the source is a URL.
- **Capability**: `ConfigSchema.SupportsURLPush` (helper `store.SupportsURLPush`), surfaced as `supports_url_push` in `apkgo stores` — true for huawei/honor/vivo only.
- A local file or authed URL produces **identical behaviour to today** — pass-through is purely additive.

## Verification

- `go build ./...`, `go vet ./...`, `go test -short ./...` — all green.
- New tests: honor `shouldURLPush` size gate (5 cases), `store.SupportsURLPush` capability lookup.
- `apkgo stores` reports `supports_url_push` for exactly huawei/honor/vivo; honor gains the `url_push_min_mb` field.

## Caveats — please validate with real credentials

These download-mode flows are **asynchronous** and could not be end-to-end tested here (no upload credentials). They're built strictly to each store's official API docs (read June 2026); a few assumptions need a real-account check:

1. **huawei** `by-url` is assumed to self-associate the downloaded package with the draft version (its response carries no `fileDestUrl` to bind, so there's no `app-file-info` step). If a bind is actually required, `submit` fails with a clear error + the AGC-console hint rather than silently.
2. **honor** polls at ~3min against the default 10-min run timeout, so a very large APK that honor can't download within the timeout will fail — bump `-t` if needed.
3. **vivo** single-package method `app.update.app` (+`apkUrl`/`apkMd5`) is inferred from the naming convention; the **split** method `app.update.subpackage.app` and the status interface `app.query.task.status` are doc-confirmed. Worth a single-APK real-account run.

## Note on base branch

Stacked on top of #16 (scheduled release) — that PR's branch is the base here, so this diff shows **only** the URL pass-through changes. Once #16 merges, GitHub retargets this PR to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
