### PR TITLE
feat: add `apkgo audit` to query review status; decouple from upload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,22 @@ go install github.com/KevinGong2013/apkgo@latest
 apkgo init [-s store1,store2] [-c config.yaml]   # Generate config file
 apkgo upload -f <apk> [flags]                     # Upload APK to stores
 apkgo doctor [-s stores] [-f apk | -p package]    # Diagnose store credentials/permissions
+apkgo audit [-f apk | -p package] [-s stores] [--watch]  # Query review (审核) status
 apkgo stores                                      # List stores and config schema (JSON)
 apkgo version                                     # Version info (JSON)
 ```
+
+### Review status (`apkgo audit`)
+
+Upload finishes at **submitted (审核中)** — it does not block waiting for the
+review outcome (tencent's old in-upload audit poll was removed). Poll review
+progress separately with `apkgo audit -p <package>` (or `-f <apk>`), which runs
+on its own context like `doctor`. `--watch [--interval 30s]` loops until every
+store reaches a terminal state (approved / rejected / withdrawn) or the global
+`-t` timeout. Each store's status is normalised to a unified `state`
+(reviewing / approved / rejected / withdrawn / unknown) with the raw label in
+`detail`. Supported: **tencent, huawei, honor, vivo, oppo, samsung** (stores
+with a review-status API; others report "audit not supported").
 
 ## Upload flags
 

--- a/cmd/audit.go
+++ b/cmd/audit.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/KevinGong2013/apkgo/v3/pkg/apkgo"
+)
+
+var (
+	flagAuditStore    string
+	flagAuditFile     string
+	flagAuditPackage  string
+	flagAuditWatch    bool
+	flagAuditInterval time.Duration
+)
+
+func init() {
+	rootCmd.AddCommand(auditCmd)
+	auditCmd.Flags().StringVarP(&flagAuditStore, "store", "s", "", "comma-separated store names (default: all configured)")
+	auditCmd.Flags().StringVarP(&flagAuditFile, "file", "f", "", "APK file (used to derive package name)")
+	auditCmd.Flags().StringVarP(&flagAuditPackage, "package", "p", "", "package name (overrides --file)")
+	auditCmd.Flags().BoolVar(&flagAuditWatch, "watch", false, "poll until every store's review resolves (or the global --timeout)")
+	auditCmd.Flags().DurationVar(&flagAuditInterval, "interval", 30*time.Second, "poll interval for --watch")
+}
+
+var auditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Query store review (审核) status for a submitted version",
+	Long: `Look up the current review status of an already-submitted app on each
+configured store — decoupled from upload. Upload now finishes at
+"submitted (审核中)"; this command polls how the review is going.
+
+Pass -f <apk> or -p <package>. With --watch it polls every --interval
+until every store reaches a terminal state (approved / rejected /
+withdrawn) or the global --timeout elapses.`,
+	Example: `  apkgo audit -p com.example.app
+  apkgo audit -f app.apk -s tencent,huawei
+  apkgo audit -p com.example.app --watch --interval 1m -t 1h`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := loadConfigForCmd()
+		if err != nil {
+			return err
+		}
+		var stores []string
+		if flagAuditStore != "" {
+			stores = strings.Split(flagAuditStore, ",")
+		}
+		job := apkgo.AuditJob{
+			Config:  cfg,
+			Stores:  stores,
+			Package: flagAuditPackage,
+			APKFile: flagAuditFile,
+		}
+
+		// Single-shot: one query, structured result on stdout.
+		if !flagAuditWatch {
+			result, err := apkgo.QueryAudit(cmd.Context(), job)
+			if err != nil {
+				return err
+			}
+			emitAudit(result)
+			if !result.AllResolved() {
+				exitCode = 1 // still reviewing — useful for scripts
+			}
+			return nil
+		}
+
+		// --watch: poll on an independent loop until every store resolves
+		// or ctx (the global --timeout) is done. Intermediate rounds print
+		// a compact line to stderr so stdout stays a single final JSON.
+		for {
+			result, err := apkgo.QueryAudit(cmd.Context(), job)
+			if err != nil {
+				return err
+			}
+			if result.AllResolved() {
+				emitAudit(result)
+				return nil
+			}
+			renderAuditProgress(result)
+			select {
+			case <-cmd.Context().Done():
+				emitAudit(result) // timed out — emit what we have
+				exitCode = 1
+				return nil
+			case <-time.After(flagAuditInterval):
+			}
+		}
+	},
+}
+
+// emitAudit writes the final structured result to stdout (json by
+// default, or a compact text table under -o text).
+func emitAudit(result *apkgo.AuditReport) {
+	if flagOutput == "text" {
+		renderAuditText(result)
+		return
+	}
+	writeOutput(result)
+}
+
+func renderAuditText(result *apkgo.AuditReport) {
+	tty := stdoutIsTTY()
+	rows := append([]apkgo.AuditStoreResult(nil), result.Stores...)
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].Store < rows[j].Store })
+	width := 8
+	for _, r := range rows {
+		if len(r.Store) > width {
+			width = len(r.Store)
+		}
+	}
+	for _, r := range rows {
+		fmt.Printf("%-*s  %s\n", width, r.Store, auditOneLiner(r, tty))
+	}
+}
+
+// renderAuditProgress prints an interim, stderr-only line per --watch round
+// so a human can follow along without corrupting the stdout JSON.
+func renderAuditProgress(result *apkgo.AuditReport) {
+	parts := make([]string, 0, len(result.Stores))
+	for _, r := range result.Stores {
+		if !r.Supported {
+			continue
+		}
+		s := string(r.State)
+		if r.Error != "" {
+			s = "error"
+		}
+		parts = append(parts, r.Store+"="+s)
+	}
+	sort.Strings(parts)
+	fmt.Fprintf(os.Stderr, "[audit] %s\n", strings.Join(parts, " "))
+}
+
+func auditOneLiner(r apkgo.AuditStoreResult, tty bool) string {
+	if !r.Supported {
+		return "   audit not supported"
+	}
+	if r.Error != "" {
+		return colorize("31", tty, "⚠ "+r.Error)
+	}
+	icon, code := auditGlyph(string(r.State))
+	line := icon + " " + string(r.State)
+	if r.Detail != "" {
+		line += " (" + r.Detail + ")"
+	}
+	return colorize(code, tty, line)
+}
+
+// auditGlyph maps a unified AuditState string to an icon + ANSI colour.
+func auditGlyph(state string) (icon, color string) {
+	switch state {
+	case "approved":
+		return "✅", "32"
+	case "rejected":
+		return "❌", "31"
+	case "withdrawn":
+		return "↩", "33"
+	case "reviewing":
+		return "⏳", "33"
+	default:
+		return "•", ""
+	}
+}
+
+func colorize(code string, tty bool, s string) string {
+	if !tty || code == "" {
+		return s
+	}
+	return "\x1b[" + code + "m" + s + "\x1b[0m"
+}

--- a/pkg/apkgo/audit.go
+++ b/pkg/apkgo/audit.go
@@ -1,0 +1,144 @@
+package apkgo
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/KevinGong2013/apkgo/v3/pkg/apk"
+	"github.com/KevinGong2013/apkgo/v3/pkg/config"
+	"github.com/KevinGong2013/apkgo/v3/pkg/httpx"
+	"github.com/KevinGong2013/apkgo/v3/pkg/store"
+)
+
+// AuditJob mirrors DiagnoseJob: look up each configured store's review
+// (审核) status for a package or APK, decoupled from uploading. Upload
+// itself now finishes at "submitted (审核中)"; callers poll review
+// progress with QueryAudit on their own schedule (e.g. a cron or a
+// `apkgo audit --watch` loop).
+type AuditJob struct {
+	// Config is the resolved store + hooks config. Required.
+	Config *config.Config
+
+	// Stores filters which configured stores to query. Empty means
+	// every store the Config has credentials for.
+	Stores []string
+
+	// Package is the app to look up. Required unless APKFile is set.
+	Package string
+
+	// APKFile is an alternative source for Package: when set and Package
+	// is empty, the APK is parsed (URL fetch supported via FetchHeaders)
+	// and its package name + version are used.
+	APKFile string
+
+	// FetchHeaders attaches HTTP headers to URL fetches of APKFile.
+	FetchHeaders map[string]string
+}
+
+// AuditStoreResult is one store's section: the unified result plus
+// whether the store has an auditor registered at all.
+type AuditStoreResult struct {
+	store.AuditResult
+	Supported bool `json:"supported"`
+}
+
+// AuditReport is the structured `apkgo audit` output.
+type AuditReport struct {
+	Package string             `json:"package,omitempty"`
+	Stores  []AuditStoreResult `json:"stores"`
+}
+
+// AllResolved reports whether every supported store has reached a terminal
+// review state (or errored). `apkgo audit --watch` stops once this is true.
+func (r *AuditReport) AllResolved() bool {
+	for _, s := range r.Stores {
+		if !s.Supported {
+			continue
+		}
+		if s.Error == "" && !s.State.Resolved() {
+			return false
+		}
+	}
+	return true
+}
+
+// QueryAudit looks up review status against the configured stores. It
+// performs no uploads (URL APK fetch is the one exception, when APKFile is
+// a URL — same temp-file lifecycle as Run/Diagnose).
+//
+// Pre-config errors (URL fetch / APK parse / no package) surface as the
+// returned error. Per-store query failures land in the AuditStoreResult's
+// Error field — QueryAudit itself returns nil so a caller can collect a
+// complete report even when some stores are unreachable.
+func QueryAudit(ctx context.Context, job AuditJob) (*AuditReport, error) {
+	if job.Config == nil {
+		return nil, fmt.Errorf("apkgo.AuditJob.Config is required")
+	}
+
+	q := store.AuditQuery{Package: job.Package}
+	if q.Package == "" && job.APKFile != "" {
+		paths, cleanup, err := httpx.FetchToTempBatch(ctx, []string{job.APKFile}, job.FetchHeaders)
+		if err != nil {
+			return nil, fmt.Errorf("fetch apk: %w", err)
+		}
+		defer cleanup()
+		apkPath := paths[0]
+		if _, err := os.Stat(apkPath); err != nil {
+			return nil, fmt.Errorf("apk file: %w", err)
+		}
+		// AABs can't be parsed for a package name; the operator must pass
+		// --package explicitly.
+		if !apk.IsAAB(apkPath) {
+			info, err := apk.Parse(apkPath)
+			if err != nil {
+				return nil, fmt.Errorf("parse apk: %w", err)
+			}
+			q.Package = info.PackageName
+			q.VersionName = info.VersionName
+			q.VersionCode = info.VersionCode
+		}
+	}
+	if q.Package == "" {
+		return nil, fmt.Errorf("a package name is required: pass --package or an APK via --file")
+	}
+
+	var filter map[string]bool
+	if len(job.Stores) > 0 {
+		filter = make(map[string]bool, len(job.Stores))
+		for _, n := range job.Stores {
+			if n = strings.TrimSpace(n); n != "" {
+				filter[n] = true
+			}
+		}
+	}
+
+	names := make([]string, 0, len(job.Config.Stores))
+	for name := range job.Config.Stores {
+		if filter != nil && !filter[name] {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		return nil, fmt.Errorf("no matching stores configured")
+	}
+
+	out := &AuditReport{Package: q.Package}
+	for _, name := range names {
+		scfg := cleanStoreCfg(job.Config.Stores[name])
+		// "type.instance" naming (e.g. script.cdn): the auditor is keyed
+		// by the type prefix, not the instance name.
+		key := name
+		if dot := strings.Index(name, "."); dot > 0 {
+			key = name[:dot]
+		}
+		res, supported := store.QueryAudit(ctx, key, scfg, q)
+		res.Store = name
+		out.Stores = append(out.Stores, AuditStoreResult{AuditResult: res, Supported: supported})
+	}
+	return out, nil
+}

--- a/pkg/store/audit.go
+++ b/pkg/store/audit.go
@@ -1,0 +1,66 @@
+package store
+
+import "context"
+
+// AuditState is the unified review state of a submitted version,
+// normalised from each store's own status codes so callers don't have to
+// learn every vendor's enum.
+type AuditState string
+
+const (
+	AuditReviewing AuditState = "reviewing" // 审核中 — submitted, pending review
+	AuditApproved  AuditState = "approved"  // 审核通过 — approved (live or pending release)
+	AuditRejected  AuditState = "rejected"  // 审核驳回 — not approved
+	AuditWithdrawn AuditState = "withdrawn" // 已撤回 — submission cancelled
+	AuditUnknown   AuditState = "unknown"   // store returned a state we don't map
+)
+
+// Resolved reports whether the review has finished (terminal state).
+// `apkgo audit --watch` stops polling once every store is Resolved.
+func (s AuditState) Resolved() bool {
+	return s == AuditApproved || s == AuditRejected || s == AuditWithdrawn
+}
+
+// AuditQuery identifies the app/version whose review status to look up.
+// VersionName/VersionCode are best-effort hints; most stores key off the
+// package name and report the latest submission.
+type AuditQuery struct {
+	Package     string
+	VersionName string
+	VersionCode int32
+}
+
+// AuditResult is one store's review status. Error is set when the query
+// itself failed (auth / network / not-found); State is meaningful only
+// when Error is empty.
+type AuditResult struct {
+	Store  string     `json:"store"`
+	State  AuditState `json:"state,omitempty"`
+	Detail string     `json:"detail,omitempty"`
+	Error  string     `json:"error,omitempty"`
+}
+
+// AuditFn looks up the current review status for one store from its raw
+// config. Like DiagnoseFn it owns its own auth/setup, so it runs on an
+// independent context fully decoupled from the upload flow — which is the
+// point: upload finishes at "submitted (审核中)" and review progress is
+// polled separately, on its own schedule.
+type AuditFn func(ctx context.Context, cfg map[string]string, q AuditQuery) AuditResult
+
+var auditors = map[string]AuditFn{}
+
+// RegisterAuditor opts a store into `apkgo audit`. Stores without one are
+// reported as unsupported (no review-status API, or not yet wired).
+func RegisterAuditor(name string, fn AuditFn) {
+	auditors[name] = fn
+}
+
+// QueryAudit runs the registered auditor for a store. The second return
+// value is false when the store has not registered one.
+func QueryAudit(ctx context.Context, name string, cfg map[string]string, q AuditQuery) (AuditResult, bool) {
+	fn, ok := auditors[name]
+	if !ok {
+		return AuditResult{}, false
+	}
+	return fn(ctx, cfg, q), true
+}

--- a/pkg/store/audit_test.go
+++ b/pkg/store/audit_test.go
@@ -1,0 +1,24 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/KevinGong2013/apkgo/v3/pkg/store"
+)
+
+// TestAuditStateResolved locks in which states `apkgo audit --watch`
+// treats as terminal (stop polling) vs still-in-flight.
+func TestAuditStateResolved(t *testing.T) {
+	resolved := []store.AuditState{store.AuditApproved, store.AuditRejected, store.AuditWithdrawn}
+	for _, s := range resolved {
+		if !s.Resolved() {
+			t.Errorf("%q.Resolved() = false, want true", s)
+		}
+	}
+	pending := []store.AuditState{store.AuditReviewing, store.AuditUnknown, store.AuditState("")}
+	for _, s := range pending {
+		if s.Resolved() {
+			t.Errorf("%q.Resolved() = true, want false", s)
+		}
+	}
+}

--- a/pkg/store/honor/honor.go
+++ b/pkg/store/honor/honor.go
@@ -38,6 +38,73 @@ func init() {
 		return New(cfg)
 	})
 	store.RegisterDiagnoser("honor", diagnose)
+	store.RegisterAuditor("honor", audit)
+}
+
+// audit is registered with `apkgo audit`. It reads the package's current
+// release/review status via get-app-current-release (which keys off appId
+// alone — no releaseId needed), independent of the upload flow.
+func audit(ctx context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
+	res := store.AuditResult{Store: "honor"}
+	s, err := New(cfg)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	appID := s.configAppID
+	if appID == "" {
+		appID, err = s.getAppID(q.Package)
+		if err != nil {
+			res.Error = err.Error()
+			return res
+		}
+	}
+	var resp struct {
+		honorResp
+		Data struct {
+			AuditResult  int    `json:"auditResult"`
+			AuditMessage string `json:"auditMessage"`
+			VersionName  string `json:"versionName"`
+		} `json:"data"`
+	}
+	httpResp, err := s.client.R().
+		SetContext(ctx).
+		SetQueryParam("appId", appID).
+		SetResult(&resp).
+		Get("/openapi/v1/publish/get-app-current-release")
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	if httpResp.IsError() {
+		res.Error = fmt.Sprintf("http %d: %s", httpResp.StatusCode(), truncateBody(httpResp.String()))
+		return res
+	}
+	if resp.Code != 0 {
+		res.Error = fmt.Sprintf("[%d] %s", resp.Code, resp.text())
+		return res
+	}
+	res.State, res.Detail = mapHonorAudit(resp.Data.AuditResult, resp.Data.AuditMessage)
+	return res
+}
+
+// mapHonorAudit maps get-app-current-release auditResult to the unified
+// state. 0=审核中, 1=审核通过, 2=审核不通过, 3=其他非审核状态, 4=编辑中未提交.
+func mapHonorAudit(auditResult int, msg string) (store.AuditState, string) {
+	switch auditResult {
+	case 0:
+		return store.AuditReviewing, ""
+	case 1:
+		return store.AuditApproved, ""
+	case 2:
+		return store.AuditRejected, msg
+	case 3:
+		return store.AuditUnknown, "non-review state"
+	case 4:
+		return store.AuditUnknown, "editing, not submitted"
+	default:
+		return store.AuditUnknown, fmt.Sprintf("auditResult=%d", auditResult)
+	}
 }
 
 // honorResp is honor's standard response envelope. Code 0 = success.

--- a/pkg/store/huawei/audit_test.go
+++ b/pkg/store/huawei/audit_test.go
@@ -1,0 +1,25 @@
+package huawei
+
+import (
+	"testing"
+
+	"github.com/KevinGong2013/apkgo/v3/pkg/store"
+)
+
+// TestMapHuaweiReleaseState locks in the releaseState → unified-state
+// mapping (the audit query's only non-trivial logic, and untestable
+// end-to-end without real credentials).
+func TestMapHuaweiReleaseState(t *testing.T) {
+	cases := map[int]store.AuditState{
+		4: store.AuditReviewing, 5: store.AuditReviewing, 12: store.AuditReviewing,
+		0: store.AuditApproved, 3: store.AuditApproved,
+		1: store.AuditRejected, 8: store.AuditRejected, 13: store.AuditRejected,
+		2: store.AuditWithdrawn, 10: store.AuditWithdrawn, 11: store.AuditWithdrawn,
+		7: store.AuditUnknown, 99: store.AuditUnknown,
+	}
+	for state, want := range cases {
+		if got, _ := mapHuaweiReleaseState(state); got != want {
+			t.Errorf("mapHuaweiReleaseState(%d) = %q, want %q", state, got, want)
+		}
+	}
+}

--- a/pkg/store/huawei/huawei.go
+++ b/pkg/store/huawei/huawei.go
@@ -35,6 +35,70 @@ func init() {
 		return New(cfg)
 	})
 	store.RegisterDiagnoser("huawei", diagnose)
+	store.RegisterAuditor("huawei", audit)
+}
+
+// audit is registered with `apkgo audit`. It reads the app's releaseState
+// via the read-only app-info query (GET), mapping it to the unified review
+// state — independent of the upload flow.
+func audit(_ context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
+	res := store.AuditResult{Store: "huawei"}
+	s, err := New(cfg)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	appID := s.configAppID
+	if appID == "" {
+		appID, err = s.fetchAppID(q.Package)
+		if err != nil {
+			res.Error = err.Error()
+			return res
+		}
+	}
+	var resp struct {
+		Ret          retInfo `json:"ret"`
+		ReleaseState int     `json:"releaseState"`
+	}
+	httpResp, err := s.client.R().
+		SetQueryParams(map[string]string{"appId": appID, "releaseType": "1"}).
+		SetResult(&resp).
+		Get("/api/publish/v2/app-info")
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	if httpResp.IsError() {
+		res.Error = fmt.Sprintf("http %d: %s", httpResp.StatusCode(), strings.TrimSpace(string(httpResp.Body())))
+		return res
+	}
+	if resp.Ret.Code != 0 {
+		res.Error = fmt.Sprintf("[%d] %s", resp.Ret.Code, resp.Ret.text())
+		return res
+	}
+	res.State, res.Detail = mapHuaweiReleaseState(resp.ReleaseState)
+	return res
+}
+
+// mapHuaweiReleaseState maps app-info releaseState (releaseType=1) to the
+// unified state. 0=已上架, 1=上架审核不通过, 2=已下架, 3=待上架(预约), 4=审核中,
+// 5=升级审核中, 6=申请下架, 7=草稿, 8=升级审核不通过, 9=下架审核不通过,
+// 10=开发者下架, 11=撤销上架, 12=预审中, 13=预审不通过.
+func mapHuaweiReleaseState(state int) (store.AuditState, string) {
+	switch state {
+	case 4, 5, 12:
+		return store.AuditReviewing, fmt.Sprintf("releaseState=%d", state)
+	case 0, 3:
+		return store.AuditApproved, fmt.Sprintf("releaseState=%d", state)
+	case 1, 8, 13:
+		return store.AuditRejected, fmt.Sprintf("releaseState=%d", state)
+	case 2, 10, 11:
+		return store.AuditWithdrawn, fmt.Sprintf("releaseState=%d", state)
+	case 7:
+		return store.AuditUnknown, "draft (草稿)"
+	default:
+		return store.AuditUnknown, fmt.Sprintf("releaseState=%d", state)
+	}
 }
 
 // authMode reflects which credential type is in effect; used by diagnostics.

--- a/pkg/store/oppo/oppo.go
+++ b/pkg/store/oppo/oppo.go
@@ -37,6 +37,63 @@ func init() {
 		return New(cfg)
 	})
 	store.RegisterDiagnoser("oppo", diagnose)
+	store.RegisterAuditor("oppo", audit)
+}
+
+// audit is registered with `apkgo audit`. It reads the latest version's
+// review status from the read-only app/info query, independent of upload.
+func audit(_ context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
+	res := store.AuditResult{Store: "oppo"}
+	s, err := New(cfg)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	app, err := s.queryApp(q.Package)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	if app == nil {
+		res.Error = fmt.Sprintf("no app found for package %s under this developer account", q.Package)
+		return res
+	}
+	res.State, res.Detail = mapOppoAudit(app.AuditStatusName, app.RefuseReason)
+	return res
+}
+
+// mapOppoAudit maps OPPO's audit_status_name (the human label from
+// app/info) to the unified state. OPPO returns a numeric audit_status plus
+// this description; we key off the description's keywords since the code
+// table isn't published in the API传包 docs. The exact label is always
+// surfaced in Detail so the operator sees ground truth regardless.
+func mapOppoAudit(name, refuse string) (store.AuditState, string) {
+	switch {
+	case containsAny(name, "拒绝", "不通过", "驳回", "失败", "打回"):
+		if refuse != "" {
+			return store.AuditRejected, name + ": " + refuse
+		}
+		return store.AuditRejected, name
+	case containsAny(name, "上线", "上架", "已发布", "通过"):
+		return store.AuditApproved, name
+	case containsAny(name, "下架", "撤销", "冻结"):
+		return store.AuditWithdrawn, name
+	case containsAny(name, "审核", "待审", "审查", "送审"):
+		return store.AuditReviewing, name
+	case name == "":
+		return store.AuditUnknown, "no audit status returned"
+	default:
+		return store.AuditUnknown, name
+	}
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
 }
 
 // errEnvelope only carries `errno` so it can be embedded in any response
@@ -489,6 +546,9 @@ type appData struct {
 	AgeLevel          string `json:"age_level"`
 	AdaptiveEquipment string `json:"adaptive_equipment"`
 	CustomerContact   string `json:"customer_contact"`
+	AuditStatus       string `json:"audit_status"`      // numeric code (审核状态对照表 not published in the API传包 docs)
+	AuditStatusName   string `json:"audit_status_name"` // human label, e.g. "上线" / "审核中"
+	RefuseReason      string `json:"refuse_reason"`
 }
 
 type uploadResultData struct {

--- a/pkg/store/samsung/audit_test.go
+++ b/pkg/store/samsung/audit_test.go
@@ -1,0 +1,31 @@
+package samsung
+
+import (
+	"testing"
+
+	"github.com/KevinGong2013/apkgo/v3/pkg/store"
+)
+
+// TestMapSamsungStatus checks the contentStatus keyword mapping, in
+// particular that the exact "approved" values win over the broader
+// "READY_FOR_"/"UNDER_" review keywords (ordering matters).
+func TestMapSamsungStatus(t *testing.T) {
+	cases := map[string]store.AuditState{
+		"FOR_SALE":                store.AuditApproved,
+		"READY_FOR_SALE":          store.AuditApproved, // exact beats the READY_FOR_ review keyword
+		"READY_FOR_CHANGE":        store.AuditApproved,
+		"SUSPENDED":               store.AuditApproved,
+		"UNDER_CONTENT_REVIEW":    store.AuditReviewing,
+		"READY_FOR_DEVICE_TEST":   store.AuditReviewing,
+		"CONTENT_REVIEW_REJECTED": store.AuditRejected, // REJECTED beats READY_/UNDER_
+		"CANCELED":                store.AuditWithdrawn,
+		"TERMINATED":              store.AuditWithdrawn,
+		"REGISTERING":             store.AuditUnknown,
+		"WHATEVER":                store.AuditUnknown,
+	}
+	for status, want := range cases {
+		if got, _ := mapSamsungStatus(status); got != want {
+			t.Errorf("mapSamsungStatus(%q) = %q, want %q", status, got, want)
+		}
+	}
+}

--- a/pkg/store/samsung/samsung.go
+++ b/pkg/store/samsung/samsung.go
@@ -38,6 +38,64 @@ func init() {
 	}, func(cfg map[string]string) (store.Store, error) {
 		return New(cfg)
 	})
+	store.RegisterAuditor("samsung", audit)
+}
+
+// audit is registered with `apkgo audit`. Galaxy Store has no
+// query-by-contentId status endpoint, so it lists the seller's apps and
+// picks out this content_id's contentStatus, mapping it to the unified
+// review state — independent of upload.
+func audit(_ context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
+	res := store.AuditResult{Store: "samsung"}
+	s, err := New(cfg)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	var list []struct {
+		ContentID     string `json:"contentId"`
+		ContentName   string `json:"contentName"`
+		ContentStatus string `json:"contentStatus"`
+	}
+	httpResp, err := s.client.R().SetResult(&list).Get("/seller/contentList")
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	if httpResp.StatusCode() >= 400 {
+		res.Error = fmt.Sprintf("http %d: %s", httpResp.StatusCode(), strings.TrimSpace(string(httpResp.Body())))
+		return res
+	}
+	for _, c := range list {
+		if c.ContentID == s.contentID {
+			res.State, res.Detail = mapSamsungStatus(c.ContentStatus)
+			return res
+		}
+	}
+	res.Error = fmt.Sprintf("content_id %s not found in seller app list", s.contentID)
+	return res
+}
+
+// mapSamsungStatus maps Galaxy Store contentStatus to the unified state.
+// There are ~38 values; we key off keywords (the raw status is always in
+// Detail). FOR_SALE/READY_FOR_SALE = approved, *_REJECTED = rejected,
+// UNDER_*/READY_*/DELAYED = in review, CANCELED/TERMINATED = withdrawn.
+func mapSamsungStatus(status string) (store.AuditState, string) {
+	u := strings.ToUpper(status)
+	switch {
+	case u == "FOR_SALE" || u == "READY_FOR_SALE" || u == "READY_FOR_CHANGE" || u == "SUSPENDED":
+		return store.AuditApproved, status
+	case strings.Contains(u, "REJECTED"):
+		return store.AuditRejected, status
+	case strings.Contains(u, "UNDER_") || strings.Contains(u, "READY_FOR_") || strings.Contains(u, "READY_TO_") || strings.Contains(u, "DELAYED"):
+		return store.AuditReviewing, status
+	case strings.Contains(u, "CANCELED") || u == "TERMINATED":
+		return store.AuditWithdrawn, status
+	case strings.Contains(u, "REGISTERING") || strings.Contains(u, "UPDATING"):
+		return store.AuditUnknown, status + " (not submitted)"
+	default:
+		return store.AuditUnknown, status
+	}
 }
 
 type Store struct {

--- a/pkg/store/tencent/tencent.go
+++ b/pkg/store/tencent/tencent.go
@@ -48,6 +48,7 @@ func init() {
 		return New(cfg)
 	})
 	store.RegisterDiagnoser("tencent", diagnose)
+	store.RegisterAuditor("tencent", audit)
 }
 
 // tencentResp is the standard response envelope. Some endpoints use
@@ -188,15 +189,11 @@ func (s *Store) upload(ctx context.Context, req *store.UploadRequest) error {
 		}
 	}
 
-	// 3. Submit update
+	// 3. Submit update. The app is now submitted and under review (审核中).
+	// Review progress is decoupled from upload — poll it with `apkgo audit`
+	// (which runs on its own context) instead of blocking the upload here.
 	rep.Phase("publishing")
-	if err := s.updateApp(pkg, appID, req, apkSerial, apkMD5, apk64Serial, apk64MD5); err != nil {
-		return fmt.Errorf("update app: %w", err)
-	}
-
-	// 4. Poll audit status
-	rep.Phase("auditing")
-	return s.pollAuditStatus(ctx, pkg, appID)
+	return s.updateApp(pkg, appID, req, apkSerial, apkMD5, apk64Serial, apk64MD5)
 }
 
 // sumFileSizes totals the byte sizes of the given paths. Empty paths are ignored.
@@ -366,56 +363,67 @@ func isAPK64BitOnly(path string) bool {
 	return apk.Is64BitOnly(abis)
 }
 
-// pollAuditStatus checks the audit status until resolved or timeout.
-//
-// A non-zero envelope `ret` is treated as a hard failure rather than a
-// transient state — without this an auth/sign failure or "app not found"
-// would loop silently for the full polling window before reporting a
-// useless "polling timed out".
-func (s *Store) pollAuditStatus(ctx context.Context, pkg, appID string) error {
-	ticker := time.NewTicker(15 * time.Second)
-	defer ticker.Stop()
-
-	for attempt := 0; attempt < 20; attempt++ {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-		}
-
-		params := url.Values{}
-		params.Set("pkg_name", pkg)
-		params.Set("app_id", appID)
-
-		var resp struct {
-			tencentResp
-			AuditStatus int    `json:"audit_status"`
-			AuditReason string `json:"audit_reason"`
-		}
-		if err := s.post("/query_app_update_status", params, &resp); err != nil {
-			return err
-		}
-		if resp.Ret != 0 {
-			return fmt.Errorf("query audit status: [%d] %s", resp.Ret, resp.text())
-		}
-
-		switch resp.AuditStatus {
-		case 3: // approved
-			return nil
-		case 2: // rejected
-			return store.Categorize(store.CategoryPolicyBlock,
-				fmt.Errorf("audit rejected: %s", resp.AuditReason))
-		case 8: // withdrawn
-			return store.Categorize(store.CategoryPolicyBlock,
-				fmt.Errorf("audit withdrawn"))
-		}
-		// status 1 = auditing, continue polling
+// audit is registered with `apkgo audit`. It looks up the latest
+// submission's review status for the package, independent of the upload
+// flow — it builds its own client from the raw config so it can run on an
+// independent context (e.g. a watch loop or a cron).
+func audit(_ context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
+	res := store.AuditResult{Store: "tencent"}
+	s, err := New(cfg)
+	if err != nil {
+		res.Error = err.Error()
+		return res
 	}
+	pkg, err := s.resolvePackage(q.Package)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	appID, err := s.resolveAppID(pkg)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	state, detail, err := s.queryAuditStatus(pkg, appID)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	res.State = state
+	res.Detail = detail
+	return res
+}
 
-	// Timeout is not an error — the update was submitted successfully and
-	// is in audit. Mirror the huawei/oppo pattern by pointing the operator
-	// at the console for the rest.
-	return nil
+// queryAuditStatus does a single audit-status query and maps Tencent's
+// audit_status to the unified AuditState (1=审核中, 2=驳回, 3=通过, 8=撤回).
+func (s *Store) queryAuditStatus(pkg, appID string) (store.AuditState, string, error) {
+	params := url.Values{}
+	params.Set("pkg_name", pkg)
+	params.Set("app_id", appID)
+
+	var resp struct {
+		tencentResp
+		AuditStatus int    `json:"audit_status"`
+		AuditReason string `json:"audit_reason"`
+	}
+	if err := s.post("/query_app_update_status", params, &resp); err != nil {
+		return "", "", err
+	}
+	if resp.Ret != 0 {
+		return "", "", fmt.Errorf("[%d] %s", resp.Ret, resp.text())
+	}
+	switch resp.AuditStatus {
+	case 1:
+		return store.AuditReviewing, "", nil
+	case 2:
+		return store.AuditRejected, resp.AuditReason, nil
+	case 3:
+		return store.AuditApproved, "", nil
+	case 8:
+		return store.AuditWithdrawn, "", nil
+	default:
+		return store.AuditUnknown, fmt.Sprintf("audit_status=%d", resp.AuditStatus), nil
+	}
 }
 
 // post makes a signed POST request to the Tencent API.

--- a/pkg/store/vivo/vivo.go
+++ b/pkg/store/vivo/vivo.go
@@ -41,6 +41,48 @@ func init() {
 		return New(cfg)
 	})
 	store.RegisterDiagnoser("vivo", diagnose)
+	store.RegisterAuditor("vivo", audit)
+}
+
+// audit is registered with `apkgo audit`. It reads the package's review
+// status via the read-only app.query.details, independent of upload.
+func audit(_ context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
+	res := store.AuditResult{Store: "vivo"}
+	s, err := New(cfg)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	app, err := s.queryApp(q.Package)
+	if err != nil {
+		res.Error = err.Error()
+		return res
+	}
+	if app == nil {
+		res.Error = fmt.Sprintf("no app found for package %s under this developer account", q.Package)
+		return res
+	}
+	res.State, res.Detail = mapVivoAuditState(int(app.Status))
+	return res
+}
+
+// mapVivoAuditState maps vivo's app.query.details 审核状态 to the unified
+// AuditState. 1=草稿, 2=待审核, 3=审核通过, 4=审核不通过, 5=撤销审核.
+func mapVivoAuditState(status int) (store.AuditState, string) {
+	switch status {
+	case 2:
+		return store.AuditReviewing, ""
+	case 3:
+		return store.AuditApproved, ""
+	case 4:
+		return store.AuditRejected, ""
+	case 5:
+		return store.AuditWithdrawn, ""
+	case 1:
+		return store.AuditUnknown, "draft (草稿) — not yet submitted"
+	default:
+		return store.AuditUnknown, fmt.Sprintf("status=%d", status)
+	}
 }
 
 type Store struct {
@@ -471,14 +513,32 @@ type uploadResp struct {
 	FileMD5      string `json:"fileMd5"`
 }
 
+// lenientInt unmarshals from either a JSON number or a quoted string,
+// and never fails the surrounding decode — vivo is inconsistent about
+// whether numeric fields are quoted, and a strict int here would break
+// the shared appDetails decode (and the doctor probe with it).
+type lenientInt int
+
+func (n *lenientInt) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(string(b), `"`)
+	if s == "" || s == "null" {
+		return nil
+	}
+	if v, err := strconv.Atoi(s); err == nil {
+		*n = lenientInt(v)
+	}
+	return nil
+}
+
 // appDetails is the slice of fields apkgo needs from `app.query.details`.
-// vivo returns more (status, app name in zh, online state, etc.) but we
-// only surface what the doctor probe reports.
+// vivo returns more (app name in zh, online state, etc.) but we only
+// surface what the doctor / audit paths report.
 type appDetails struct {
-	PackageName string `json:"packageName"`
-	AppName     string `json:"appName"`
-	VersionName string `json:"versionName"`
-	VersionCode string `json:"versionCode"`
+	PackageName string     `json:"packageName"`
+	AppName     string     `json:"appName"`
+	VersionName string     `json:"versionName"`
+	VersionCode string     `json:"versionCode"`
+	Status      lenientInt `json:"status"` // 审核状态: 1草稿/2待审核/3通过/4不通过/5撤销
 }
 
 // queryApp calls the read-only `app.query.details` method. Used by the


### PR DESCRIPTION
## What

Two things:

1. **Decouple review-polling from upload.** Tencent's upload used to block, polling the audit result until it resolved (or timed out). That's removed — upload now finishes at **submitted (审核中)**, exactly like every other store.
2. **A unified, independent review-status query.** New `apkgo audit` command (and `apkgo.QueryAudit`) that polls how the review is going, decoupled from upload and running on its own context — mirroring the `doctor` pattern.

```bash
apkgo audit -p com.example.app                 # one-shot, structured JSON
apkgo audit -f app.apk -s tencent,huawei       # specific stores
apkgo audit -p com.example.app --watch -t 1h   # loop until all resolve
```

## How

`store.AuditFn` / `RegisterAuditor` / `QueryAudit` (mirrors `DiagnoseFn`/`RegisterDiagnoser`/`Diagnose`) → `apkgo.QueryAudit(ctx, AuditJob)` → `cmd/audit.go`. Each store builds its own client from raw config (independent context), looks up the latest submission's status, and normalises it to a unified `AuditState` (`reviewing` / `approved` / `rejected` / `withdrawn` / `unknown`); the raw store label is always in `detail`. `--watch` loops every `--interval` until every store is terminal (`AuditState.Resolved()`) or the global `-t` elapses — intermediate rounds print to stderr so stdout stays a single final JSON.

| Store | Query endpoint | Status field → mapping |
|---|---|---|
| **tencent** | `query_app_update_status` | `audit_status` 1=审核中→reviewing, 2→rejected, 3→approved, 8→withdrawn |
| **huawei** | `GET /api/publish/v2/app-info` | `releaseState` 4/5/12→reviewing, 0/3→approved, 1/8/13→rejected, 2/10/11→withdrawn |
| **honor** | `get-app-current-release` (appId only) | `auditResult` 0→reviewing, 1→approved, 2→rejected, 3/4→unknown |
| **vivo** | `app.query.details` | `status` 2→reviewing, 3→approved, 4→rejected, 5→withdrawn |
| **oppo** | `GET /resource/v1/app/info` | `audit_status_name` keyword-mapped |
| **samsung** | `GET /seller/contentList` (filter by content_id) | `contentStatus` (~38 values) keyword-mapped |

## Verification

- `go build ./...`, `go vet ./...`, `go test -short ./...` — all green.
- New tests: `AuditState.Resolved`, `mapHuaweiReleaseState`, `mapSamsungStatus` (incl. keyword ordering: exact `READY_FOR_SALE` beats the `READY_FOR_` review keyword; `*_REJECTED` beats `UNDER_`).
- `apkgo audit` checked: in the command list, flags present (`--watch`/`--interval`/`-f`/`-p`/`-s`), errors cleanly without a package.

## Caveats — please validate with real credentials

Built strictly to each store's docs; **not** end-to-end tested (no upload credentials). Confidence varies:

- **High** (status codes are doc-confirmed): tencent, huawei, honor, vivo.
- **oppo**: the audit-status code table isn't published in the API传包 docs, so the state is keyword-mapped from `audit_status_name` (the human label). The exact label is always surfaced in `detail`, so you see ground truth even if the keyword bucket is off.
- **samsung**: the `contentList` response shape (bare array vs paginated) is unverified, and `contentStatus` has ~38 values keyword-mapped — the least-certain store.
- **huawei**: assumes `releaseState` is at the response top level (sibling of `ret`).

## Note on base branch

Stacked on #17 (URL pass-through), which is stacked on #16 (scheduled release). This PR's base is #17's branch, so the diff shows **only** the audit changes. Merge order: #16 → #17 → this; GitHub retargets each to `main` as its parent merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
