### PR TITLE
fix(audit): thread ctx into huawei/oppo/vivo/samsung status queries

### DIFF
--- a/pkg/store/huawei/huawei.go
+++ b/pkg/store/huawei/huawei.go
@@ -41,7 +41,7 @@ func init() {
 // audit is registered with `apkgo audit`. It reads the app's releaseState
 // via the read-only app-info query (GET), mapping it to the unified review
 // state — independent of the upload flow.
-func audit(_ context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
+func audit(ctx context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
 	res := store.AuditResult{Store: "huawei"}
 	s, err := New(cfg)
 	if err != nil {
@@ -61,6 +61,7 @@ func audit(_ context.Context, cfg map[string]string, q store.AuditQuery) store.A
 		ReleaseState int     `json:"releaseState"`
 	}
 	httpResp, err := s.client.R().
+		SetContext(ctx).
 		SetQueryParams(map[string]string{"appId": appID, "releaseType": "1"}).
 		SetResult(&resp).
 		Get("/api/publish/v2/app-info")

--- a/pkg/store/oppo/oppo.go
+++ b/pkg/store/oppo/oppo.go
@@ -42,14 +42,14 @@ func init() {
 
 // audit is registered with `apkgo audit`. It reads the latest version's
 // review status from the read-only app/info query, independent of upload.
-func audit(_ context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
+func audit(ctx context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
 	res := store.AuditResult{Store: "oppo"}
 	s, err := New(cfg)
 	if err != nil {
 		res.Error = err.Error()
 		return res
 	}
-	app, err := s.queryApp(q.Package)
+	app, err := s.queryApp(ctx, q.Package)
 	if err != nil {
 		res.Error = err.Error()
 		return res
@@ -206,7 +206,7 @@ func (s *Store) upload(ctx context.Context, req *store.UploadRequest) error {
 
 	// 1. Query app info
 	rep.Phase("query")
-	app, err := s.queryApp(req.PackageName)
+	app, err := s.queryApp(ctx, req.PackageName)
 	if err != nil {
 		return fmt.Errorf("query app: %w", err)
 	}
@@ -297,7 +297,7 @@ func sumFileSizes(paths ...string) (int64, error) {
 	return total, nil
 }
 
-func (s *Store) queryApp(pkgName string) (*appData, error) {
+func (s *Store) queryApp(ctx context.Context, pkgName string) (*appData, error) {
 	data := url.Values{}
 	data.Set("pkg_name", pkgName)
 	var resp struct {
@@ -305,6 +305,7 @@ func (s *Store) queryApp(pkgName string) (*appData, error) {
 		Data *appData `json:"data"`
 	}
 	httpResp, err := s.client.R().
+		SetContext(ctx).
 		SetResult(&resp).
 		SetQueryParamsFromValues(s.sign(data)).
 		Get("/resource/v1/app/info")
@@ -585,7 +586,7 @@ func diagnose(ctx context.Context, cfg map[string]string, hint store.DiagnoseHin
 		return probes
 	}
 
-	app, err := s.queryApp(hint.Package)
+	app, err := s.queryApp(ctx, hint.Package)
 	if err != nil {
 		probes = append(probes, store.Probe{Name: "app-info", Status: "fail", Error: err.Error()})
 		return probes

--- a/pkg/store/samsung/samsung.go
+++ b/pkg/store/samsung/samsung.go
@@ -45,7 +45,7 @@ func init() {
 // query-by-contentId status endpoint, so it lists the seller's apps and
 // picks out this content_id's contentStatus, mapping it to the unified
 // review state — independent of upload.
-func audit(_ context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
+func audit(ctx context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
 	res := store.AuditResult{Store: "samsung"}
 	s, err := New(cfg)
 	if err != nil {
@@ -57,7 +57,7 @@ func audit(_ context.Context, cfg map[string]string, q store.AuditQuery) store.A
 		ContentName   string `json:"contentName"`
 		ContentStatus string `json:"contentStatus"`
 	}
-	httpResp, err := s.client.R().SetResult(&list).Get("/seller/contentList")
+	httpResp, err := s.client.R().SetContext(ctx).SetResult(&list).Get("/seller/contentList")
 	if err != nil {
 		res.Error = err.Error()
 		return res

--- a/pkg/store/vivo/vivo.go
+++ b/pkg/store/vivo/vivo.go
@@ -46,14 +46,14 @@ func init() {
 
 // audit is registered with `apkgo audit`. It reads the package's review
 // status via the read-only app.query.details, independent of upload.
-func audit(_ context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
+func audit(ctx context.Context, cfg map[string]string, q store.AuditQuery) store.AuditResult {
 	res := store.AuditResult{Store: "vivo"}
 	s, err := New(cfg)
 	if err != nil {
 		res.Error = err.Error()
 		return res
 	}
-	app, err := s.queryApp(q.Package)
+	app, err := s.queryApp(ctx, q.Package)
 	if err != nil {
 		res.Error = err.Error()
 		return res
@@ -549,11 +549,11 @@ type appDetails struct {
 // and resty's auto-decode keys off content-type — so SetResult would
 // silently leave the struct zero-valued, making a real auth failure
 // look like "no app found".
-func (s *Store) queryApp(packageName string) (*appDetails, error) {
+func (s *Store) queryApp(ctx context.Context, packageName string) (*appDetails, error) {
 	params := s.signParams("app.query.details", map[string]string{
 		"packageName": packageName,
 	})
-	httpResp, err := s.client.R().SetQueryParams(params).Post("")
+	httpResp, err := s.client.R().SetContext(ctx).SetQueryParams(params).Post("")
 	if err != nil {
 		return nil, err
 	}
@@ -595,7 +595,7 @@ func diagnose(ctx context.Context, cfg map[string]string, hint store.DiagnoseHin
 		return probes
 	}
 
-	app, err := s.queryApp(hint.Package)
+	app, err := s.queryApp(ctx, hint.Package)
 	if err != nil {
 		probes = append(probes, store.Probe{Name: "app-info", Status: "fail", Error: err.Error()})
 		return probes


### PR DESCRIPTION
Low-severity follow-up from the v3.3.0 review. The `apkgo audit` auditors for huawei/oppo/vivo/samsung dropped `ctx` and their resty clients have no timeout — so a hung HTTP read during `audit --watch` could stall the loop past the global `-t`. This threads `ctx` into those status queries (oppo/vivo `queryApp` gains a `ctx` param, which also hardens their `doctor` probes). tencent is already bounded by `SetTimeout(60s)`; honor already wires `ctx`.

No behaviour change beyond enabling cancellation. build/vet/`test -short` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)