### PR TITLE
fix(oppo): carry electronic_cert_url through publish (#23)

### DIFF
--- a/pkg/store/oppo/oppo.go
+++ b/pkg/store/oppo/oppo.go
@@ -414,6 +414,7 @@ func (s *Store) publish(req *store.UploadRequest, app *appData, apkInfos []apkIn
 	}
 	values.Set("test_desc", "submitted by apkgo")
 	values.Set("copyright_url", app.CopyrightURL)
+	values.Set("electronic_cert_url", app.ElectronicCertURL)
 	values.Set("business_username", app.BusinessUsername)
 	values.Set("business_email", app.BusinessEmail)
 	values.Set("business_mobile", app.BusinessMobile)
@@ -545,6 +546,7 @@ type appData struct {
 	IconURL           string `json:"icon_url"`
 	PicURL            string `json:"pic_url"`
 	CopyrightURL      string `json:"copyright_url"`
+	ElectronicCertURL string `json:"electronic_cert_url"` // 电子版权证书; copyright_url 已弃用,改用此字段
 	BusinessUsername  string `json:"business_username"`
 	BusinessEmail     string `json:"business_email"`
 	BusinessMobile    string `json:"business_mobile"`


### PR DESCRIPTION
Fixes #23

## Problem

Updating an **already-live** app on OPPO failed with:

```
publish: [911001] 软件版权证明不能为空
```

even though the 电子版权证书 PDF was uploaded in the dev console (and the live version was approved with it). Huawei / honor / xiaomi / vivo succeeded in the same run.

## Root cause

OPPO moved copyright qualification from the deprecated `copyright_url` field to `electronic_cert_url`. `/resource/v1/app/info` returns:

```json
"copyright_url": "",
"electronic_cert_url": "https://store.heytapimage.com/.../xxxxxxxx.pdf"
```

But `appData` had no `electronic_cert_url` field (so `queryApp` dropped it) and `publish()` only set `copyright_url`. The publish request thus sent an empty copyright proof → `911001`.

## Fix

apkgo already follows a "query `app/info` → echo back" pattern. This adds `electronic_cert_url` to that passthrough, identical to the existing `copyright_url` handling — no new config or file upload required.

- Add `ElectronicCertURL` to `appData` so `queryApp` reads it.
- `values.Set("electronic_cert_url", app.ElectronicCertURL)` in `publish()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)