### PR TITLE
fix(oppo): send copyright proof in copyright_url for electronic cert accounts (#25)

### DIFF
--- a/pkg/store/oppo/oppo.go
+++ b/pkg/store/oppo/oppo.go
@@ -413,7 +413,14 @@ func (s *Store) publish(req *store.UploadRequest, app *appData, apkInfos []apkIn
 		values.Set("sche_online_time", store.BeijingLocalTime(*req.ReleaseTime))
 	}
 	values.Set("test_desc", "submitted by apkgo")
-	values.Set("copyright_url", app.CopyrightURL)
+	// /app/upd validates 软件版权证明 from copyright_url. Accounts that uploaded
+	// an electronic copyright certificate (电子版权证书) get an empty copyright_url
+	// from /app/info with the URL only in electronic_cert_url, so fall back to it.
+	copyrightURL := app.CopyrightURL
+	if copyrightURL == "" {
+		copyrightURL = app.ElectronicCertURL
+	}
+	values.Set("copyright_url", copyrightURL)
 	values.Set("electronic_cert_url", app.ElectronicCertURL)
 	values.Set("business_username", app.BusinessUsername)
 	values.Set("business_email", app.BusinessEmail)


### PR DESCRIPTION
Fixes #25.

## Problem

After #24, publishing to OPPO still fails with `publish: [911001] 软件版权证明不能为空` for accounts whose copyright proof was uploaded as an *electronic copyright certificate* (电子版权证书).

OPPO's `/resource/v1/app/upd` validates 软件版权证明 from the **`copyright_url`** field. On those accounts, `/app/info` returns the URL only under `electronic_cert_url` with `copyright_url` empty. #24 added `electronic_cert_url` to the publish request, but `/app/upd` does not read the proof from that field — so the error persisted.

## Fix

In `pkg/store/oppo/oppo.go` `publish()`, fall back to `electronic_cert_url` when `copyright_url` is empty. Only changes behavior in the failing case; no regression when `copyright_url` is already set. Verified end-to-end against the live account per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)