### PR TITLE
fix(huawei): classify the "packages exceeds upper limit" error

### DIFF
--- a/pkg/store/huawei/audit_test.go
+++ b/pkg/store/huawei/audit_test.go
@@ -23,3 +23,37 @@ func TestMapHuaweiReleaseState(t *testing.T) {
 		}
 	}
 }
+
+// TestClassifyHuawei locks in the "app's packages exceeds the upper limit"
+// classification from https://github.com/KevinGong2013/apkgo/issues/31 —
+// an AGC-side draft-version package cap, not an apkgo bug, so it must map
+// to config_invalid (human fixes the console, not an auto-retry) rather
+// than the generic unknown bucket.
+func TestClassifyHuawei(t *testing.T) {
+	cases := []struct {
+		name string
+		ret  retInfo
+		want store.Category
+	}{
+		{
+			name: "package limit exceeded",
+			ret:  retInfo{Code: 204144662, Message: "[cds]add apk failed, additional msg is [the app's packages exceeds the upper limit.]"},
+			want: store.CategoryConfigInvalid,
+		},
+		{
+			name: "same code, unrelated message",
+			ret:  retInfo{Code: 204144662, Message: "registeredEntity can not be empty"},
+			want: store.CategoryUnknown,
+		},
+		{
+			name: "unrelated code",
+			ret:  retInfo{Code: 204144660, Message: "package is parsing"},
+			want: store.CategoryUnknown,
+		},
+	}
+	for _, tc := range cases {
+		if got := classifyHuawei(tc.ret); got != tc.want {
+			t.Errorf("%s: classifyHuawei(%+v) = %q, want %q", tc.name, tc.ret, got, tc.want)
+		}
+	}
+}

--- a/pkg/store/huawei/huawei.go
+++ b/pkg/store/huawei/huawei.go
@@ -424,9 +424,38 @@ func (s *Store) uploadAPK(appID, apkPath string, rep progress.Reporter) error {
 		return err
 	}
 	if updateResp.Ret.Code != 0 {
-		return fmt.Errorf("update file info: [%d] %s", updateResp.Ret.Code, updateResp.Ret.text())
+		return store.Categorize(classifyHuawei(updateResp.Ret),
+			fmt.Errorf("update file info: [%d] %s%s", updateResp.Ret.Code, updateResp.Ret.text(), packageLimitHint(updateResp.Ret)))
 	}
 	return nil
+}
+
+// packageLimitHint appends actionable guidance when Huawei rejects a file-info
+// update because the app already has too many package files attached to its
+// current (unreleased) draft version. Each upload attempt adds a new package
+// file rather than replacing the previous one, so this creeps up over repeated
+// retries on the same version — it is an AGC-side account limit, not an apkgo
+// bug, and the only fix is a human deleting old/unused packages from the AGC
+// console (版本发布 → 该版本 → 包管理) before retrying.
+func packageLimitHint(ret retInfo) string {
+	if classifyHuawei(ret) == store.CategoryConfigInvalid {
+		return " (AGC 限制单个版本可关联的安装包数量，非 apkgo 问题；请到 AppGallery Connect 控制台的版本发布页删除该版本下不再使用的旧安装包后重试)"
+	}
+	return ""
+}
+
+// classifyHuawei maps Huawei's numeric ret codes to the unified Category.
+// Codes are heavily reused across unrelated failures (see isParsingInProgress),
+// so classification must inspect the message text, not the code alone.
+func classifyHuawei(ret retInfo) store.Category {
+	msg := strings.ToLower(ret.text())
+	switch ret.Code {
+	case 204144662:
+		if strings.Contains(msg, "exceeds the upper limit") || strings.Contains(msg, "packages exceeds") {
+			return store.CategoryConfigInvalid
+		}
+	}
+	return store.CategoryUnknown
 }
 
 // submitPackageByURL hands Huawei a developer-hosted download URL


### PR DESCRIPTION
## Summary
- Fixes #31 — huawei uploads intermittently fail with `[204144662] [cds]add apk failed, additional msg is [the app's packages exceeds the upper limit.]`
- This is an AppGallery Connect account-side limit on how many package files can be attached to a single (unreleased) draft version — not an apkgo bug. It typically builds up from repeated upload attempts on the same version, since each attempt adds a new package file rather than replacing the previous one.
- Classifies this specific error (code `204144662` + message) as `config_invalid` instead of falling through to `unknown`, so cloud/CI callers know a human needs to intervene rather than auto-retrying.
- Appends an actionable hint to the error message directing the user to delete unused old packages from the AGC console before retrying.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/store/huawei/... ./pkg/store/...`
- [x] `gofmt -l` / `go vet` clean on changed files
- [x] Added `TestClassifyHuawei` covering: the exact reported message, the same code with an unrelated message (stays `unknown`), and an unrelated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)